### PR TITLE
Remove `allow` declaration in favour of anonymous import

### DIFF
--- a/cargo/src/main.rs
+++ b/cargo/src/main.rs
@@ -2,8 +2,8 @@
 #![no_main]
 
 use esp_idf_svc;
-{% endunless %}#[allow(unused_imports)]
-use esp_idf_sys; // If using the `binstart` feature of `esp-idf-sys`, always keep this module imported
+{% endunless %}
+use esp_idf_sys as _; // If using the `binstart` feature of `esp-idf-sys`, always keep this module imported
 
 {% unless std %}use log::*;
 


### PR DESCRIPTION
A neat little trick I've been using with the [atomic emulation trap handler](https://github.com/esp-rs/riscv-atomic-emulation-trap/blob/bbfad4c0ecfaea59a66c28a4ecb8419f515b287f/src/lib.rs#L9) to include a dependency without unused warnings.