### PR TITLE
Default to v4.4

### DIFF
--- a/cargo/.cargo/config.toml
+++ b/cargo/.cargo/config.toml
@@ -24,9 +24,10 @@ rustflags = ["-C", "default-linker-libraries"]
 [unstable]
 {% if std %}
 build-std = ["std", "panic_abort"]{% else %}build-std = ["core", "alloc", "panic_abort"]{% endif %}
-build-std-features = ["panic_immediate_abort"]
+{% if espidfver != "v4.3.2" %}#{% endif %}build-std-features = ["panic_immediate_abort"] # required for older esp-idf versions without a realpath implementation
 
 [env]
+# Note: these variables are not used when using pio builder
 # Enables the esp-idf-sys "native" build feature (`cargo build --features native`) to build against ESP-IDF stable (v4.4)
 {% if espidfver != "v4.4" %}#{% endif %}ESP_IDF_VERSION = { value = "branch:release/v4.4" }
 # Enables the esp-idf-sys "native" build feature (`cargo build --features native`) to build against ESP-IDF master (v5.0)

--- a/cargo/Cargo.toml
+++ b/cargo/Cargo.toml
@@ -13,8 +13,8 @@ debug = true # Symbols are nice and they don't increase the size on Flash
 opt-level = "z"
 
 [features]
-{% if espidfver <> 'v4.3.2' %}default = ["native"]
-{% endif %}native = ["esp-idf-sys/native"]
+{% if espidfver == "v4.3.2" %}default = ["pio"]
+{% endif %}pio = ["esp-idf-sys/pio"]
 
 [dependencies]
 {% if std %}esp-idf-sys = { version = "0.31", features = ["binstart"] }

--- a/cargo/cargo-generate.toml
+++ b/cargo/cargo-generate.toml
@@ -12,4 +12,4 @@ description1 = "My description"
 mcu = { type = "string", prompt = "MCU", choices = ["esp32", "esp32s2", "esp32s3", "esp32c3"], default = "esp32" }
 toolchain = { type = "string", prompt = "Rust toolchain (beware: nightly works only for esp32c3!)", choices = ["esp", "nightly"], default = "esp" }
 std = { type = "bool", prompt = "STD support", default = true }
-espidfver = { type = "string", prompt = "ESP-IDF native build version (v4.3.2 = previous stable, v4.4 = stable, v5.0 = development; NOTE: applicable only with `cargo build --features native`)", choices = ["v4.3.2", "v4.4", "v5.0"], default = "v4.3.2" }
+espidfver = { type = "string", prompt = "ESP-IDF native build version (v4.3.2 = previous stable, v4.4 = stable, v5.0 = development; NOTE: applicable only with `cargo build --features native`)", choices = ["v4.4", "v4.3.2", "v5.0"], default = "v4.4" }

--- a/cargo/rust-toolchain.toml
+++ b/cargo/rust-toolchain.toml
@@ -1,7 +1,3 @@
 [toolchain]
-{% if toolchain == "esp" %}
-channel = "esp"
-{% endif %}
-{% if toolchain == "nightly" %}
-channel = "nightly"
-{% endif %}
+{% if toolchain == "esp" %}channel = "esp"{% endif %}
+{% if toolchain == "nightly" %}channel = "nightly"{% endif %}


### PR DESCRIPTION
v4.4 is now officially released. v4.4 has most (all?) the patches we need from the Rust side, including `realpath` so we can now remove `panic_immediate_abort` feature.