### PR TITLE
add CONFIG_FREERTOS_HZ=1000 to sdkconfig.defaults

### DIFF
--- a/cargo/sdkconfig.defaults
+++ b/cargo/sdkconfig.defaults
@@ -1,9 +1,9 @@
 # Rust often needs a bit of an extra main task stack size compared to C (the default is 3K)
 CONFIG_ESP_MAIN_TASK_STACK_SIZE=7000
 
-# Set FreeRTOS kernel tick frequency to 1000 Hz
-# This allows to use 1 ms granuality for thread sleeps
-CONFIG_FREERTOS_HZ=1000
+# Use this to set FreeRTOS kernel tick frequency to 1000 Hz (100 Hz by default).
+# This allows to use 1 ms granuality for thread sleeps (10 ms by default).
+#CONFIG_FREERTOS_HZ=1000
 
 # Workaround for https://github.com/espressif/esp-idf/issues/7631
 CONFIG_MBEDTLS_CERTIFICATE_BUNDLE=n

--- a/cargo/sdkconfig.defaults
+++ b/cargo/sdkconfig.defaults
@@ -1,6 +1,10 @@
 # Rust often needs a bit of an extra main task stack size compared to C (the default is 3K)
 CONFIG_ESP_MAIN_TASK_STACK_SIZE=7000
 
+# Set FreeRTOS kernel tick frequency to 1000 Hz
+# This allows to use 1 ms granuality for thread sleeps
+CONFIG_FREERTOS_HZ=1000
+
 # Workaround for https://github.com/espressif/esp-idf/issues/7631
 CONFIG_MBEDTLS_CERTIFICATE_BUNDLE=n
 CONFIG_MBEDTLS_CERTIFICATE_BUNDLE_DEFAULT_FULL=n


### PR DESCRIPTION
By default it is 100 Hz, which means all thread sleeps under 10 ms do not work as expected.
So this would just busy wait and does not give other threads chance to run. And it can be very confusing for the user.

```rust
loop {
   thread::sleep(Duration::from_millis(9))
}
```

So from user perspective it makes sense to explicitly define CONFIG_FREERTOS_HZ here. It would be less surprising then.

I learned it hard way here: https://github.com/esp-rs/esp-idf-sys/issues/71