### PR TITLE
Fixed a syntax error in the PlatformIO guide

### DIFF
--- a/README-pio.md
+++ b/README-pio.md
@@ -45,7 +45,7 @@ cargo install cargo-pio
 ## Generate the project
 
 ```sh
-cargo pio new <your-project-name> --platforms espressif32 --framework espidf [--board <your-board-name>]
+cargo pio new <your-project-name> --platform espressif32 --frameworks espidf [--board <your-board-name>]
 ```
 
 You can see supported boards by typing

--- a/README-pio.md
+++ b/README-pio.md
@@ -45,7 +45,7 @@ cargo install cargo-pio
 ## Generate the project
 
 ```sh
-cargo pio new <your-project-name> --platform espressif32 --framework espidf [--board <your-board-name>]
+cargo pio new <your-project-name> --platforms espressif32 --framework espidf [--board <your-board-name>]
 ```
 
 You can see supported boards by typing


### PR DESCRIPTION
Fixed a typo in the project creation command of the PlatformIO guide: command failed with

```
error: Found argument '--framework' which wasn't expected, or isn't valid in this context
	Did you mean --frameworks?
```