### PR TITLE
Improve devcontainer support

### DIFF
--- a/cargo/.devcontainer/Dockerfile
+++ b/cargo/.devcontainer/Dockerfile
@@ -32,25 +32,11 @@ ADD --chown=${CONTAINER_USER}:${CONTAINER_GROUP} \
 
 RUN chmod a+x ${INSTALL_RUST_TOOLCHAIN} \
     && ./${INSTALL_RUST_TOOLCHAIN} \
-    --extra-crates "ldproxy cargo-espflash" \
+    --extra-crates "ldproxy cargo-espflash wokwi-server web-flash" \
     --clear-cache "YES" --export-file /home/${CONTAINER_USER}/export-esp.sh \
     --esp-idf-version "${ESP_IDF_VERSION}" \
     --minified-esp-idf "YES" \
     --build-target "${ESP_BOARD}"
-
-# Install web-flash and wokwi-server
-RUN curl -L https://github.com/bjoernQ/esp-web-flash-server/releases/latest/download/web-flash-x86_64-unknown-linux-gnu.zip \
-    -o /home/${CONTAINER_USER}/.cargo/bin/web-flash.zip \
-    && unzip /home/${CONTAINER_USER}/.cargo/bin/web-flash.zip \
-    -d /home/${CONTAINER_USER}/.cargo/bin/ \
-    && rm /home/${CONTAINER_USER}/.cargo/bin/web-flash.zip
-RUN chmod u+x /home/${CONTAINER_USER}/.cargo/bin/web-flash
-RUN curl -L https://github.com/MabezDev/wokwi-server/releases/latest/download/wokwi-server-x86_64-unknown-linux-gnu.zip \
-    -o /home/${CONTAINER_USER}/.cargo/bin/wokwi-server.zip \
-    && unzip /home/${CONTAINER_USER}/.cargo/bin/wokwi-server.zip \
-    -d /home/${CONTAINER_USER}/.cargo/bin/ \
-    && rm /home/${CONTAINER_USER}/.cargo/bin/wokwi-server.zip
-RUN chmod u+x /home/${CONTAINER_USER}/.cargo/bin/wokwi-server
 
 # Activate ESP environment
 RUN echo "source /home/${CONTAINER_USER}/export-esp.sh" >> ~/.bashrc

--- a/cargo/.devcontainer/Dockerfile
+++ b/cargo/.devcontainer/Dockerfile
@@ -37,7 +37,7 @@ RUN chmod a+x ${INSTALL_RUST_TOOLCHAIN} \
     --esp-idf-version "${ESP_IDF_VERSION}" \
     --minified-esp-idf "YES" \
     --build-target "${ESP_BOARD}" \
-    && rustup component add clippy
+    && rustup component add clippy rustfmt
 
 # Activate ESP environment
 RUN echo "source /home/${CONTAINER_USER}/export-esp.sh" >> ~/.bashrc

--- a/cargo/.devcontainer/Dockerfile
+++ b/cargo/.devcontainer/Dockerfile
@@ -36,7 +36,8 @@ RUN chmod a+x ${INSTALL_RUST_TOOLCHAIN} \
     --clear-cache "YES" --export-file /home/${CONTAINER_USER}/export-esp.sh \
     --esp-idf-version "${ESP_IDF_VERSION}" \
     --minified-esp-idf "YES" \
-    --build-target "${ESP_BOARD}"
+    --build-target "${ESP_BOARD}" \
+    && rustup component add clippy
 
 # Activate ESP environment
 RUN echo "source /home/${CONTAINER_USER}/export-esp.sh" >> ~/.bashrc

--- a/cargo/.gitpod.Dockerfile
+++ b/cargo/.gitpod.Dockerfile
@@ -34,4 +34,6 @@ RUN chmod a+x ${INSTALL_RUST_TOOLCHAIN} \
     --clear-cache "YES" --export-file /home/${CONTAINER_USER}/export-esp.sh \
     --esp-idf-version "${ESP_IDF_VERSION}" \
     --minified-esp-idf "YES" \
-    --build-target "${ESP_BOARD}"
+    --build-target "${ESP_BOARD}" \
+    && rustup component add clippy rustfmt
+

--- a/cargo/.gitpod.Dockerfile
+++ b/cargo/.gitpod.Dockerfile
@@ -30,21 +30,8 @@ ADD --chown=${CONTAINER_USER}:${CONTAINER_GROUP} \
     /home/${CONTAINER_USER}/${INSTALL_RUST_TOOLCHAIN}
 RUN chmod a+x ${INSTALL_RUST_TOOLCHAIN} \
     && ./${INSTALL_RUST_TOOLCHAIN} \
-    --extra-crates "cargo-espflash ldproxy" \
+    --extra-crates "ldproxy cargo-espflash wokwi-server web-flash" \
     --clear-cache "YES" --export-file /home/${CONTAINER_USER}/export-esp.sh \
     --esp-idf-version "${ESP_IDF_VERSION}" \
     --minified-esp-idf "YES" \
     --build-target "${ESP_BOARD}"
-# Install web-flash and wokwi-server
-RUN curl -L https://github.com/bjoernQ/esp-web-flash-server/releases/latest/download/web-flash-x86_64-unknown-linux-gnu.zip \
-    -o /home/${CONTAINER_USER}/.cargo/bin/web-flash.zip \
-    && unzip /home/${CONTAINER_USER}/.cargo/bin/web-flash.zip \
-    -d /home/${CONTAINER_USER}/.cargo/bin/ \
-    && rm /home/${CONTAINER_USER}/.cargo/bin/web-flash.zip
-RUN chmod u+x /home/${CONTAINER_USER}/.cargo/bin/web-flash
-RUN curl -L https://github.com/MabezDev/wokwi-server/releases/latest/download/wokwi-server-x86_64-unknown-linux-gnu.zip \
-    -o /home/${CONTAINER_USER}/.cargo/bin/wokwi-server.zip \
-    && unzip /home/${CONTAINER_USER}/.cargo/bin/wokwi-server.zip \
-    -d /home/${CONTAINER_USER}/.cargo/bin/ \
-    && rm /home/${CONTAINER_USER}/.cargo/bin/wokwi-server.zip
-RUN chmod u+x /home/${CONTAINER_USER}/.cargo/bin/wokwi-server

--- a/cargo/cargo-generate.toml
+++ b/cargo/cargo-generate.toml
@@ -1,19 +1,35 @@
 [template]
 cargo_generate_version = ">=0.10.0"
-ignore = [
-    ".git",
-    ".github",
-    "README.md",
-    "cmake",
-]
+ignore = [".git", ".github", "README.md", "cmake"]
 description1 = "My description"
 
 [placeholders]
-mcu = { type = "string", prompt = "MCU", choices = ["esp32", "esp32s2", "esp32s3", "esp32c3"], default = "esp32" }
-toolchain = { type = "string", prompt = "Rust toolchain (beware: nightly works only for esp32c3!)", choices = ["esp", "nightly"], default = "esp" }
+mcu = { type = "string", prompt = "MCU", choices = [
+    "esp32",
+    "esp32s2",
+    "esp32s3",
+    "esp32c3",
+], default = "esp32" }
+toolchain = { type = "string", prompt = "Rust toolchain (beware: nightly works only for esp32c3!)", choices = [
+    "esp",
+    "nightly",
+], default = "esp" }
 std = { type = "bool", prompt = "STD support", default = true }
-espidfver = { type = "string", prompt = "ESP-IDF native build version (v4.3.2 = previous stable, v4.4 = stable, mainline = UNSTABLE)", choices = ["v4.4", "v4.3.2", "mainline"], default = "v4.4" }
+espidfver = { type = "string", prompt = "ESP-IDF native build version (v4.3.2 = previous stable, v4.4 = stable, mainline = UNSTABLE)", choices = [
+    "v4.4",
+    "v4.3.2",
+    "mainline",
+], default = "v4.4" }
 devcontainer = { type = "bool", prompt = "Configure project to use Dev Containers (VS Code, GitHub Codespaces and Gitpod)? (beware: Dev Containers not available for esp-idf v4.3.2)", default = false }
 
 [conditional.'devcontainer == false']
-ignore = [".devcontainer/", ".gitpod.Dockerfile", ".gitpod.yml", ".vscode/launch.json", ".vscode/tasks.json", ".dockerignore", "build.sh", "run-wokwi.sh", "flash.sh"]
+ignore = [
+    ".devcontainer/",
+    ".dockerignore",
+    ".gitpod.Dockerfile",
+    ".gitpod.yml",
+    ".vscode/launch.json",
+    ".vscode/tasks.json",
+    "docs/",
+    "scripts/",
+]

--- a/cargo/docs/README.md
+++ b/cargo/docs/README.md
@@ -17,7 +17,8 @@ This repository offers Dev Containers supports for:
 
 If using VS Code or GitHub Codespaces, you can pull the image instead of building it
 from the Dockerfile by selecting the `image` property instead of `build` in
-`.devcontainer/devcontainer.json`.
+`.devcontainer/devcontainer.json`. Further customization of the Dev Container can
+be achived, see [.devcontainer.json reference](https://code.visualstudio.com/docs/remote/devcontainerjson-reference).
 
 When using Dev Containers, some tooling to facilitate building, flashing and
 simulating in Wokwi is also added.


### PR DESCRIPTION
- Install `wokwi-server` and `web-flash` via rust installer, this will use binary packages if available
- Ignore `docs` and `script` folders when not using devcontainers.
- Install `clippy` and `rustfmt` for RustAnalyzer 
- Add `.devcontainer.json` reference link in documentation