### PR TITLE
Toolchain and Rust edition Update

### DIFF
--- a/cargo/.devcontainer/Dockerfile
+++ b/cargo/.devcontainer/Dockerfile
@@ -7,7 +7,7 @@ ENV LANG=C.UTF-8
 # Arguments
 ARG CONTAINER_USER=esp
 ARG CONTAINER_GROUP=esp
-ARG TOOLCHAIN_VERSION=1.61.0.0
+ARG TOOLCHAIN_VERSION=1.62.0.0
 ARG ESP_IDF_VERSION=release/v4.4
 ARG ESP_BOARD=esp32
 ARG INSTALL_RUST_TOOLCHAIN=install-rust-toolchain.sh
@@ -33,7 +33,7 @@ ADD --chown=${CONTAINER_USER}:${CONTAINER_GROUP} \
 RUN chmod a+x ${INSTALL_RUST_TOOLCHAIN} \
     && ./${INSTALL_RUST_TOOLCHAIN} \
     --extra-crates "ldproxy cargo-espflash wokwi-server web-flash" \
-    --clear-cache "YES" --export-file /home/${CONTAINER_USER}/export-esp.sh \
+    --export-file /home/${CONTAINER_USER}/export-esp.sh \
     --esp-idf-version "${ESP_IDF_VERSION}" \
     --minified-esp-idf "YES" \
     --build-target "${ESP_BOARD}" \

--- a/cargo/.gitpod.Dockerfile
+++ b/cargo/.gitpod.Dockerfile
@@ -6,7 +6,7 @@ ENV LANG=C.UTF-8
 # ARGS
 ARG CONTAINER_USER=gitpod
 ARG CONTAINER_GROUP=gitpod
-ARG TOOLCHAIN_VERSION=1.61.0.0
+ARG TOOLCHAIN_VERSION=1.62.0.0
 ARG ESP_IDF_VERSION=
 {%- if espidfver == "mainline" -%}
 "master"
@@ -31,7 +31,7 @@ ADD --chown=${CONTAINER_USER}:${CONTAINER_GROUP} \
 RUN chmod a+x ${INSTALL_RUST_TOOLCHAIN} \
     && ./${INSTALL_RUST_TOOLCHAIN} \
     --extra-crates "ldproxy cargo-espflash wokwi-server web-flash" \
-    --clear-cache "YES" --export-file /home/${CONTAINER_USER}/export-esp.sh \
+    --export-file /home/${CONTAINER_USER}/export-esp.sh \
     --esp-idf-version "${ESP_IDF_VERSION}" \
     --minified-esp-idf "YES" \
     --build-target "${ESP_BOARD}" \

--- a/cargo/Cargo.toml
+++ b/cargo/Cargo.toml
@@ -2,7 +2,7 @@
 name = "{{project-name}}"
 version = "0.1.0"
 authors = ["{{authors}}"]
-edition = "2018"
+edition = "2021"
 resolver = "2"
 
 [profile.release]


### PR DESCRIPTION
- Upgraded Rust version to `2021`
- Updated to rust toolchain to `1.62.0.0`
  - Removed `--clear-cache "YES"` as it [now the default valule](https://github.com/esp-rs/rust-build/blob/597a8d97bdce2f4f33f8898592f7c9f24bd71883/install-rust-toolchain.sh#L22)