### PR TITLE
Improve CI to allow checking PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,10 +30,10 @@ jobs:
         run: cargo install ldproxy
       # - name: (STD, PIO, V4.3.2) Generate (PR)
       #   if: ${{ github.event_name == 'pull_request' }}
-      #   run: cargo generate --git https://github.com/SergioGasquez/esp-idf-template --branch ${{ github.head_ref }} cargo --name test --vcs none --silent -d mcu=esp32c3 -d std=true -d espidfver=v4.3.2 -d devcontainer=false
+      #   run: cargo generate --git https://github.com//${{ github.repository }} --branch ${{ github.head_ref }} cargo --name test --vcs none --silent -d mcu=esp32c3 -d std=true -d espidfver=v4.3.2 -d devcontainer=false
        # - name: (STD, PIO, V4.3.2) Generate
       #   if: ${{ github.event_name != 'pull_request' }}
-      #   run: cargo generate --git https://github.com/SergioGasquez/esp-idf-template --branch ${{ github.ref_name }} cargo --name test --vcs none --silent -d mcu=esp32c3 -d std=true -d espidfver=v4.3.2 -d devcontainer=false
+      #   run: cargo generate --git https://github.com/esp-rs/esp-idf-template --branch ${{ github.ref_name }} cargo --name test --vcs none --silent -d mcu=esp32c3 -d std=true -d espidfver=v4.3.2 -d devcontainer=false
       # - name: (STD, PIO, V4.3.2) Build | Fmt Check
       #   run: cd test; cargo fmt -- --check
       # - name: (STD, PIO, V4.3.2) Build | Clippy
@@ -45,7 +45,7 @@ jobs:
         run: cargo generate --git https://github.com/${{ github.repository }} --branch ${{ github.head_ref }} cargo --name testnostd --vcs none --silent -d mcu=esp32c3 -d std=false -d espidfver=v4.4 -d devcontainer=false
       - name: (NOSTD, NATIVE, V4.4) Generate
         if: ${{ github.event_name != 'pull_request' }}
-        run: cargo generate --git https://github.com/SergioGasquez/esp-idf-template --branch ${{ github.ref_name }} cargo --name testnostd --vcs none --silent -d mcu=esp32c3 -d std=false -d espidfver=v4.4 -d devcontainer=false
+        run: cargo generate --git https://github.com/esp-rs/esp-idf-template --branch ${{ github.ref_name }} cargo --name testnostd --vcs none --silent -d mcu=esp32c3 -d std=false -d espidfver=v4.4 -d devcontainer=false
       - name: (NOSTD, NATIVE, V4.4) Build | Fmt Check
         run: cd testnostd; cargo fmt -- --check
       - name: (NOSTD, NATIVE, V4.4) Build | Clippy
@@ -57,7 +57,7 @@ jobs:
         run: cargo generate --git https://github.com/${{ github.repository }} --branch ${{ github.head_ref }} cmake --name testidf --vcs none --silent -d toolchain=nightly -d std=true -d espidfver=v4.4
       - name: (STD, CMake, V4.4) Generate
         if: ${{ github.event_name != 'pull_request' }}
-        run: cargo generate --git https://github.com/SergioGasquez/esp-idf-template --branch ${{ github.ref_name }} cmake --name testidf --vcs none --silent -d toolchain=nightly -d std=true -d espidfver=v4.4
+        run: cargo generate --git https://github.com/esp-rs/esp-idf-template --branch ${{ github.ref_name }} cmake --name testidf --vcs none --silent -d toolchain=nightly -d std=true -d espidfver=v4.4
       - name: (STD, CMake, V4.4) ESP-IDF | Checkout
         run: git clone https://github.com/espressif/esp-idf; git -C esp-idf checkout release/v4.4
       - name: (STD, CMake, V4.4) ESP-IDF | Install Tooling
@@ -85,13 +85,13 @@ jobs:
         run: cargo generate --git https://github.com/${{ github.repository }} --branch ${{ github.head_ref }} cargo --name test-${{ matrix.board }} --vcs none --silent -d mcu=${{ matrix.board }} -d toolchain=esp -d std=${{ matrix.std }} -d espidfver=v4.4 -d devcontainer=true
       - name: Generate Project - Xtensa Targets
         if: (matrix.board == 'esp32' || matrix.board == 'esp32s2' || matrix.board == 'esp32s3') && github.event_name != 'pull_request'
-        run: cargo generate --git https://github.com/SergioGasquez/esp-idf-template --branch ${{ github.ref_name }} cargo --name test-${{ matrix.board }} --vcs none --silent -d mcu=${{ matrix.board }} -d toolchain=esp -d std=${{ matrix.std }} -d espidfver=v4.4 -d devcontainer=true
+        run: cargo generate --git https://github.com/esp-rs/esp-idf-template --branch ${{ github.ref_name }} cargo --name test-${{ matrix.board }} --vcs none --silent -d mcu=${{ matrix.board }} -d toolchain=esp -d std=${{ matrix.std }} -d espidfver=v4.4 -d devcontainer=true
       - name: Generate Project - RiscV Targets (PR)
         if: matrix.board == 'esp32c3' && github.event_name == 'pull_request'
         run: cargo generate --git https://github.com/${{ github.repository }} --branch ${{ github.head_ref }} cargo --name test-${{ matrix.board }} --vcs none --silent -d mcu=${{ matrix.board }} -d toolchain=nightly -d std=${{ matrix.std }} -d espidfver=v4.4 -d devcontainer=true
       - name: Generate Project - RiscV Targets
         if: matrix.board == 'esp32c3' && github.event_name != 'pull_request'
-        run: cargo generate --git https://github.com/SergioGasquez/esp-idf-template --branch ${{ github.ref_name }} cargo --name test-${{ matrix.board }} --vcs none --silent -d mcu=${{ matrix.board }} -d toolchain=nightly -d std=${{ matrix.std }} -d espidfver=v4.4 -d devcontainer=true
+        run: cargo generate --git https://github.com/esp-rs/esp-idf-template --branch ${{ github.ref_name }} cargo --name test-${{ matrix.board }} --vcs none --silent -d mcu=${{ matrix.board }} -d toolchain=nightly -d std=${{ matrix.std }} -d espidfver=v4.4 -d devcontainer=true
       - name: Update ownership
         run: |
           sudo chown 1000:1000 -R test-${{ matrix.board }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,15 +81,15 @@ jobs:
           tar xf "/home/runner/.cargo/bin/cargo-generate.tar.gz" -C /home/runner/.cargo/bin
           chmod u+x /home/runner/.cargo/bin/cargo-generate
       - name: Generate Project - Xtensa Targets (PR)
-        if: matrix.board == 'esp32' || matrix.board == 'esp32s2' || matrix.board == 'esp32s3' && github.event_name == 'pull_request'
+        if: (matrix.board == 'esp32' || matrix.board == 'esp32s2' || matrix.board == 'esp32s3') && github.event_name == 'pull_request'
         run: cargo generate --git https://github.com/SergioGasquez/esp-idf-template --branch ${{ github.head_ref }} cargo --name test-${{ matrix.board }} --vcs none --silent -d mcu=${{ matrix.board }} -d toolchain=esp -d std=${{ matrix.std }} -d espidfver=v4.4 -d devcontainer=true
       - name: Generate Project - Xtensa Targets
-        if: matrix.board == 'esp32' || matrix.board == 'esp32s2' || matrix.board == 'esp32s3' && github.event_name != 'pull_request'
+        if: (matrix.board == 'esp32' || matrix.board == 'esp32s2' || matrix.board == 'esp32s3') && github.event_name != 'pull_request'
         run: cargo generate --git https://github.com/SergioGasquez/esp-idf-template --branch ${{ github.ref_name }} cargo --name test-${{ matrix.board }} --vcs none --silent -d mcu=${{ matrix.board }} -d toolchain=esp -d std=${{ matrix.std }} -d espidfver=v4.4 -d devcontainer=true
       - name: Generate Project - RiscV Targets (PR)
         if: matrix.board == 'esp32c3' && github.event_name == 'pull_request'
         run: cargo generate --git https://github.com/SergioGasquez/esp-idf-template --branch ${{ github.head_ref }} cargo --name test-${{ matrix.board }} --vcs none --silent -d mcu=${{ matrix.board }} -d toolchain=nightly -d std=${{ matrix.std }} -d espidfver=v4.4 -d devcontainer=true
-      - name: Generate Project - RiscV Targets (PR)
+      - name: Generate Project - RiscV Targets
         if: matrix.board == 'esp32c3' && github.event_name != 'pull_request'
         run: cargo generate --git https://github.com/SergioGasquez/esp-idf-template --branch ${{ github.ref_name }} cargo --name test-${{ matrix.board }} --vcs none --silent -d mcu=${{ matrix.board }} -d toolchain=nightly -d std=${{ matrix.std }} -d espidfver=v4.4 -d devcontainer=true
       - name: Update ownership

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,6 @@ name: CI
 on:
   push:
     branches:
-      - master
   pull_request:
   schedule:
     - cron: '50 7 * * *'
@@ -29,24 +28,36 @@ jobs:
         run: cargo install cargo-generate
       - name: Setup | ldproxy
         run: cargo install ldproxy
-      # - name: (STD, PIO, V4.3.2) Generate
-      #   run: cargo generate --git https://github.com/esp-rs/esp-idf-template cargo --name test --vcs none --silent -d mcu=esp32c3 -d toolchain=nightly -d std=true -d espidfver=v4.3.2 -d devcontainer=false
+      # - name: (STD, PIO, V4.3.2) Generate (PR)
+      #   if: ${{ github.event_name == 'pull_request' }}
+      #   run: cargo generate --git https://github.com/SergioGasquez/esp-idf-template --branch ${{ github.head_ref }} cargo --name test --vcs none --silent -d mcu=esp32c3 -d std=true -d espidfver=v4.3.2 -d devcontainer=false
+       # - name: (STD, PIO, V4.3.2) Generate
+      #   if: ${{ github.event_name != 'pull_request' }}
+      #   run: cargo generate --git https://github.com/SergioGasquez/esp-idf-template --branch ${{ github.ref_name }} cargo --name test --vcs none --silent -d mcu=esp32c3 -d std=true -d espidfver=v4.3.2 -d devcontainer=false
       # - name: (STD, PIO, V4.3.2) Build | Fmt Check
       #   run: cd test; cargo fmt -- --check
       # - name: (STD, PIO, V4.3.2) Build | Clippy
       #   run: cd test; cargo clippy --features pio --no-deps -- -Dwarnings
       # - name: (STD, PIO, V4.3.2) Build | Compile
       #   run: cd test; cargo build --features pio
+      - name: (NOSTD, NATIVE, V4.4) Generate (PR)
+        if: ${{ github.event_name == 'pull_request' }}
+        run: cargo generate --git https://github.com/SergioGasquez/esp-idf-template --branch ${{ github.head_ref }} cargo --name testnostd --vcs none --silent -d mcu=esp32c3 -d std=false -d espidfver=v4.4 -d devcontainer=false
       - name: (NOSTD, NATIVE, V4.4) Generate
-        run: cargo generate --git https://github.com/ivmarkov/esp-idf-template cargo --name testnostd --vcs none --silent -d mcu=esp32c3 -d std=false -d espidfver=v4.4 -d devcontainer=false
+        if: ${{ github.event_name != 'pull_request' }}
+        run: cargo generate --git https://github.com/SergioGasquez/esp-idf-template --branch ${{ github.ref_name }} cargo --name testnostd --vcs none --silent -d mcu=esp32c3 -d std=false -d espidfver=v4.4 -d devcontainer=false
       - name: (NOSTD, NATIVE, V4.4) Build | Fmt Check
         run: cd testnostd; cargo fmt -- --check
       - name: (NOSTD, NATIVE, V4.4) Build | Clippy
         run: cd testnostd; cargo clippy --no-deps -- -Dwarnings
       - name: (NOSTD, NATIVE, V4.4) Build | Compile
         run: cd testnostd; cargo build
+      - name: (STD, CMake, V4.4) Generate (PR)
+        if: ${{ github.event_name == 'pull_request' }}
+        run: cargo generate --git https://github.com/SergioGasquez/esp-idf-template --branch ${{ github.head_ref }} cmake --name testidf --vcs none --silent -d toolchain=nightly -d std=true -d espidfver=v4.4
       - name: (STD, CMake, V4.4) Generate
-        run: cargo generate --git https://github.com/esp-rs/esp-idf-template cmake --name testidf --vcs none --silent -d toolchain=nightly -d std=true -d espidfver=v4.4
+        if: ${{ github.event_name != 'pull_request' }}
+        run: cargo generate --git https://github.com/SergioGasquez/esp-idf-template --branch ${{ github.ref_name }} cmake --name testidf --vcs none --silent -d toolchain=nightly -d std=true -d espidfver=v4.4
       - name: (STD, CMake, V4.4) ESP-IDF | Checkout
         run: git clone https://github.com/espressif/esp-idf; git -C esp-idf checkout release/v4.4
       - name: (STD, CMake, V4.4) ESP-IDF | Install Tooling
@@ -69,12 +80,18 @@ jobs:
           sudo curl -L "https://github.com/cargo-generate/cargo-generate/releases/latest/download/cargo-generate-v0.15.2-x86_64-unknown-linux-gnu.tar.gz" -o "/home/runner/.cargo/bin/cargo-generate.tar.gz"
           tar xf "/home/runner/.cargo/bin/cargo-generate.tar.gz" -C /home/runner/.cargo/bin
           chmod u+x /home/runner/.cargo/bin/cargo-generate
+      - name: Generate Project - Xtensa Targets (PR)
+        if: matrix.board == 'esp32' || matrix.board == 'esp32s2' || matrix.board == 'esp32s3' && github.event_name == 'pull_request'
+        run: cargo generate --git https://github.com/SergioGasquez/esp-idf-template --branch ${{ github.head_ref }} cargo --name test-${{ matrix.board }} --vcs none --silent -d mcu=${{ matrix.board }} -d toolchain=esp -d std=${{ matrix.std }} -d espidfver=v4.4 -d devcontainer=true
       - name: Generate Project - Xtensa Targets
-        if: matrix.board == 'esp32' || matrix.board == 'esp32s2' || matrix.board == 'esp32s3'
-        run: cargo generate --git https://github.com/esp-rs/esp-idf-template cargo --name test-${{ matrix.board }} --vcs none --silent -d mcu=${{ matrix.board }} -d toolchain=esp -d std=${{ matrix.std }} -d espidfver=v4.4 -d devcontainer=true
-      - name: Generate Project - RiscV Targets
-        if: matrix.board == 'esp32c3'
-        run: cargo generate --git https://github.com/esp-rs/esp-idf-template cargo --name test-${{ matrix.board }} --vcs none --silent -d mcu=${{ matrix.board }} -d toolchain=nightly -d std=${{ matrix.std }} -d espidfver=v4.4 -d devcontainer=true
+        if: matrix.board == 'esp32' || matrix.board == 'esp32s2' || matrix.board == 'esp32s3' && github.event_name != 'pull_request'
+        run: cargo generate --git https://github.com/SergioGasquez/esp-idf-template --branch ${{ github.ref_name }} cargo --name test-${{ matrix.board }} --vcs none --silent -d mcu=${{ matrix.board }} -d toolchain=esp -d std=${{ matrix.std }} -d espidfver=v4.4 -d devcontainer=true
+      - name: Generate Project - RiscV Targets (PR)
+        if: matrix.board == 'esp32c3' && github.event_name == 'pull_request'
+        run: cargo generate --git https://github.com/SergioGasquez/esp-idf-template --branch ${{ github.head_ref }} cargo --name test-${{ matrix.board }} --vcs none --silent -d mcu=${{ matrix.board }} -d toolchain=nightly -d std=${{ matrix.std }} -d espidfver=v4.4 -d devcontainer=true
+      - name: Generate Project - RiscV Targets (PR)
+        if: matrix.board == 'esp32c3' && github.event_name != 'pull_request'
+        run: cargo generate --git https://github.com/SergioGasquez/esp-idf-template --branch ${{ github.ref_name }} cargo --name test-${{ matrix.board }} --vcs none --silent -d mcu=${{ matrix.board }} -d toolchain=nightly -d std=${{ matrix.std }} -d espidfver=v4.4 -d devcontainer=true
       - name: Update ownership
         run: |
           sudo chown 1000:1000 -R test-${{ matrix.board }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
         run: cargo install ldproxy
       # - name: (STD, PIO, V4.3.2) Generate (PR)
       #   if: ${{ github.event_name == 'pull_request' }}
-      #   run: cargo generate --git https://github.com//${{ github.repository }} --branch ${{ github.head_ref }} cargo --name test --vcs none --silent -d mcu=esp32c3 -d std=true -d espidfver=v4.3.2 -d devcontainer=false
+      #   run: cargo generate --git https://github.com/${{ github.repository }} --branch ${{ github.head_ref }} cargo --name test --vcs none --silent -d mcu=esp32c3 -d std=true -d espidfver=v4.3.2 -d devcontainer=false
        # - name: (STD, PIO, V4.3.2) Generate
       #   if: ${{ github.event_name != 'pull_request' }}
       #   run: cargo generate --git https://github.com/esp-rs/esp-idf-template --branch ${{ github.ref_name }} cargo --name test --vcs none --silent -d mcu=esp32c3 -d std=true -d espidfver=v4.3.2 -d devcontainer=false

--- a/cargo/Cargo.toml
+++ b/cargo/Cargo.toml
@@ -19,7 +19,7 @@ pio = ["esp-idf-sys/pio"]
 {% if std %}esp-idf-sys = { version = "0.31.6", features = ["binstart"] }
 {% else %}log = { version = "0.4", default-features = false }
 esp-idf-sys = { version = "0.31.6", default-features = false, features = ["binstart", "panic_handler", "alloc_handler"] }
-esp-idf-svc = { git = "https://github.com/esp-rs/esp-idf-svc.git", default-features = false, features = ["alloc"] }{% endif %}
+esp-idf-svc = { version = "0.42", default-features = false, features = ["alloc"] }{% endif %}
 
 [build-dependencies]
 embuild = "0.29"

--- a/cargo/Cargo.toml
+++ b/cargo/Cargo.toml
@@ -19,7 +19,7 @@ pio = ["esp-idf-sys/pio"]
 {% if std %}esp-idf-sys = { version = "0.31.6", features = ["binstart"] }
 {% else %}log = { version = "0.4", default-features = false }
 esp-idf-sys = { version = "0.31.6", default-features = false, features = ["binstart", "panic_handler", "alloc_handler"] }
-esp-idf-svc = { version = "0.42", default-features = false, features = ["alloc"] }{% endif %}
+esp-idf-svc = { git = "https://github.com/esp-rs/esp-idf-svc.git", default-features = false, features = ["alloc"] }{% endif %}
 
 [build-dependencies]
 embuild = "0.29"


### PR DESCRIPTION
`cargo generate` commands on the CI should use the testing repo instead of always using `esp-rs/esp-idf-tempalte` on `master` branch, so I introduced changes to use the propper repo and branch that we want to test.