### PR TITLE
Add custom runner and update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,41 @@
 # Rust on ESP-IDF "Hello, World" template
 
-A "Hello, world!" template of a Rust binary crate for the ESP-IDF framework.
+A "Hello, world!" template, to use with [cargo-generate](https://github.com/cargo-generate/cargo-generate), of a Rust binary crate for the ESP-IDF framework.
 
 This is the crate you get when running `cargo new`, but augmented with extra configuration so that it does build for the ESP32[XX] with ESP-IDF and (by default) with STD support.
+
+To generate a project using this template:
+* Cargo-first approach:
+  ```sh
+  cargo generate https://github.com/esp-rs/esp-idf-template cargo
+  ```
+  After running the command, there will be a few prompts:
+  - `Project Name`: Name of the crate.
+  - `Which MCU to target?`: SoC model.
+  - `STD support`: When `true`, adds support for [Rust Standard Library](https://doc.rust-lang.org/std/). Otherwise, we will use [Rust Core Library](https://doc.rust-lang.org/core/index.html).
+  - `ESP-IDF Version`: ESP-IDF branch/tag to use. Possible choices:
+    - [`v.4.4`](https://github.com/espressif/esp-idf/tree/release/v4.4): Stable
+    - [`v.4.3.2`](https://github.com/espressif/esp-idf/tree/v4.3.2): Previous stable
+    - [`mainline`](https://github.com/espressif/esp-idf/tree/master): **Unstable**
+  - `Dev Containers support?`: Adds support for:
+     -  [VS Code Dev Containers](https://code.visualstudio.com/docs/remote/containers#_quick-start-open-an-existing-folder-in-a-container)
+     -  [GitHub Codespaces](https://docs.github.com/en/codespaces/developing-in-codespaces/creating-a-codespace)
+     -  [Gitpod](https://www.gitpod.io)
+    Dev Containers also have integration with [Wokwi simulator](https://wokwi.com/) and allow flashing from the container using [web flash](https://github.com/bjoernQ/esp-web-flash-server).
+* CMake-first apporach:
+   ```sh
+   cargo generate https://github.com/esp-rs/esp-idf-template cmake
+   ```
+  After running the command, there will be a few prompts:
+  - `Project Name`: Name of the crate.
+  - `Rust toolchain`: Selects the `channel` in the [toolchain file](https://rust-lang.github.io/rustup/overrides.html#the-toolchain-file) to use. Select `nightly` for ESP32-C3 and `esp` for the other targets.
+  - `STD support`: When `true`, adds support for [Rust Standard Library](https://doc.rust-lang.org/std/). Otherwise, we will use [Rust Core Library](https://doc.rust-lang.org/core/index.html).
 
 Or if you rather
 * ... want to mix Rust and C/C++ in a traditional ESP-IDF `idf.py` CMake project - [follow these instructions](README-cmake.md)
 * ... want to mix Rust and C/C++ with PlatformIO - [follow these instructions](README-pio.md)
 
 ![CI](https://github.com/esp-rs/esp-idf-template/actions/workflows/ci.yml/badge.svg)
-
-## Dev Containers
-When using `cargo` template, there will be a question regarding Dev Containers support,
-if we say `yes` we will have instant support for:
--  [Gitpod](https://gitpod.io/)
-   - ["Open in Gitpod" button](https://www.gitpod.io/docs/getting-started#open-in-gitpod-button)
--  [VS Code Dev Containers](https://code.visualstudio.com/docs/remote/containers#_quick-start-open-an-existing-folder-in-a-container)
--  [GitHub Codespaces](https://docs.github.com/en/codespaces/developing-in-codespaces/creating-a-codespace)
 
 ## Prerequisites
 

--- a/cargo/.cargo/config.toml
+++ b/cargo/.cargo/config.toml
@@ -7,15 +7,19 @@
 
 [target.xtensa-esp32-espidf]
 linker = "ldproxy"
+runner = "espflash --monitor"
 
 [target.xtensa-esp32s2-espidf]
 linker = "ldproxy"
+runner = "espflash --monitor"
 
 [target.xtensa-esp32s3-espidf]
 linker = "ldproxy"
+runner = "espflash --monitor"
 
 [target.riscv32imc-esp-espidf]
 linker = "ldproxy"
+runner = "espflash --monitor"
 
 # Future - necessary for the experimental "native build" of esp-idf-sys with ESP32C3
 # See also https://github.com/ivmarkov/embuild/issues/16


### PR DESCRIPTION
- Add custom runner so `cargo run` flashes and open a serial monitor.
- Improve Readme so we have a short description of every prompt.