### PR TITLE
.gitignore: fix absolute path references in cmake template

### DIFF
--- a/cmake/.gitignore
+++ b/cmake/.gitignore
@@ -1,5 +1,5 @@
 /.vscode
 /.embuild
-/build
-/target
-/Cargo.lock
+build/
+components/*/target/
+Cargo.lock


### PR DESCRIPTION
A slash in the beginning or middle of a gitignore pattern causes the
pattern to match only relative to the directory of the .gitignore
file[1]. This means that the 'Cargo.lock' and 'target' patterns were
not matching anything and the build pattern was only matching the top
level build.

[1]: https://git-scm.com/docs/gitignore
