### PR TITLE
cmake template: remove panic_immediate_abort for new idf versions

### DIFF
--- a/cargo/.cargo/config.toml
+++ b/cargo/.cargo/config.toml
@@ -28,7 +28,9 @@ rustflags = ["-C", "default-linker-libraries"]
 [unstable]
 {% if std %}
 build-std = ["std", "panic_abort"]{% else %}build-std = ["core", "alloc", "panic_abort"]{% endif %}
-{% if espidfver != "v4.3.2" %}#{% endif %}build-std-features = ["panic_immediate_abort"] # Required for older ESP-IDF versions without a realpath implementation
+# Required for older ESP-IDF versions without a realpath implementation.
+# Enabling panic_immediate_abort may remove 100K+ from binary size but panic messages will not be printed.
+{% if espidfver != "v4.3.2" %}#{% endif %}build-std-features = ["panic_immediate_abort"]
 
 [env]
 # Note: these variables are not used when using pio builder

--- a/cmake/cargo-generate.toml
+++ b/cmake/cargo-generate.toml
@@ -4,3 +4,8 @@ cargo_generate_version = ">=0.10.0"
 [placeholders]
 toolchain = { type = "string", prompt = "Rust toolchain (beware: nightly works only for esp32c3!)", choices = ["esp", "nightly"], default = "esp" }
 std = { type = "bool", prompt = "STD support", default = true }
+espidfver = { type = "string", prompt = "ESP-IDF native build version (v4.3.2 = previous stable, v4.4 = stable, mainline = UNSTABLE)", choices = [
+    "v4.4",
+    "v4.3.2",
+    "mainline",
+], default = "v4.4" }

--- a/cmake/components/rust-{{project-name}}/.cargo/config.toml
+++ b/cmake/components/rust-{{project-name}}/.cargo/config.toml
@@ -1,0 +1,6 @@
+[unstable]
+{% if std %}
+build-std = ["std", "panic_abort"]{% else %}build-std = ["core", "alloc", "panic_abort"]{% endif %}
+# Required for older ESP-IDF versions without a realpath implementation.
+# Enabling panic_immediate_abort may remove 100K+ from binary size but panic messages will not be printed.
+{% if espidfver != "v4.3.2" %}#{% endif %}build-std-features = ["panic_immediate_abort"]

--- a/cmake/components/rust-{{project-name}}/CMakeLists.txt
+++ b/cmake/components/rust-{{project-name}}/CMakeLists.txt
@@ -30,12 +30,6 @@ else()
     set(CARGO_BUILD_ARG "--release")
 endif()
 
-{% if std %}
-set(CARGO_BUILD_STD_ARG -Zbuild-std=std,panic_abort -Zbuild-std-features=panic_immediate_abort)
-{% else %}
-set(CARGO_BUILD_STD_ARG -Zbuild-std=core,alloc,panic_abort -Zbuild-std-features=panic_immediate_abort)
-{% endif %}
-
 set(CARGO_PROJECT_DIR "${CMAKE_CURRENT_LIST_DIR}")
 set(CARGO_BUILD_DIR "${CMAKE_CURRENT_BINARY_DIR}")
 set(CARGO_TARGET_DIR "${CARGO_BUILD_DIR}/target")
@@ -63,7 +57,7 @@ ExternalProject_Add(
         CARGO_CMAKE_BUILD_SDKCONFIG=${sdkconfig}
         CARGO_CMAKE_BUILD_ESP_IDF=${idf_path}
         CARGO_CMAKE_BUILD_COMPILER=${CMAKE_C_COMPILER}
-        cargo build --target ${RUST_TARGET} --target-dir ${CARGO_TARGET_DIR} ${CARGO_BUILD_ARG} ${CARGO_BUILD_STD_ARG}
+        cargo build --target ${RUST_TARGET} --target-dir ${CARGO_TARGET_DIR} ${CARGO_BUILD_ARG}
     INSTALL_COMMAND ""
     BUILD_ALWAYS TRUE
     TMP_DIR "${CARGO_BUILD_DIR}/tmp"


### PR DESCRIPTION
build-std-features=panic_immediate_abort causes panics to not print
their error messages which is a bad developer experience. Similar to
the Cargo template, do not set this flag for newer espidf versions.
