### PR TITLE
Update link_patches() comment to reflect current status

### DIFF
--- a/cargo/src/main.rs
+++ b/cargo/src/main.rs
@@ -7,8 +7,8 @@
 
 #[no_mangle]
 {% endunless %}fn main() {
-    // Temporary. Will disappear once ESP-IDF 4.4 is released, but for now it is necessary to call this function once,
-    // or else some patches to the runtime implemented by esp-idf-sys might not link properly.
+    // It is necessary to call this function once. Otherwise some patches to the runtime
+    // implemented by esp-idf-sys might not link properly. See https://github.com/esp-rs/esp-idf-template/issues/71
     esp_idf_sys::link_patches();
 {% if std %}
     println!("Hello, world!");{% else %}


### PR DESCRIPTION
Fixes #71 

I'm not very satisfied with the provided URL. It currently only tells the user *that* it's needed, not exactly why. Do you have a better link we can use that helps the user understand the reason for `link_patches`?