### PR TITLE
Remove anyhow as a build dependency

### DIFF
--- a/cargo/Cargo.toml
+++ b/cargo/Cargo.toml
@@ -23,4 +23,3 @@ esp-idf-svc = { version = "0.43.1", default-features = false, features = ["alloc
 
 [build-dependencies]
 embuild = "0.30.4"
-anyhow = "1"

--- a/cargo/build.rs
+++ b/cargo/build.rs
@@ -1,5 +1,6 @@
 // Necessary because of this issue: https://github.com/rust-lang/cargo/issues/9641
-fn main() -> anyhow::Result<()> {
+fn main() -> Result<(), Box<dyn std::error::Error>> {
     embuild::build::CfgArgs::output_propagated("ESP_IDF")?;
-    embuild::build::LinkArgs::output_propagated("ESP_IDF")
+    embuild::build::LinkArgs::output_propagated("ESP_IDF")?;
+    Ok(())
 }


### PR DESCRIPTION
This is subjective. But I did not feel like the `anyhow` dependency helped really. A whole dependency just to save a few characters in a single place in `build.rs`. I personally think that a template should be light weight and easy to understand. Not that `anyhow` complicated things by a lot, but it also did not reduce complexity. So my suggestion is that we get rid of it and just handle this error with standard Rust.