### PR TITLE
Add an conditional option to add esp-idf-svc/hal 

### DIFF
--- a/cargo/Cargo.toml
+++ b/cargo/Cargo.toml
@@ -22,7 +22,12 @@ esp-idf-hal = { version = "0.40.1"}
 esp-idf-svc = { version = "0.45.0"}
 {% endif %} 
 {% if hal == "Yes (all features)" %}
-esp-idf-hal = { version = "0.40.1", features = ["default","embassy-sync","critical-section","edge-executor"]}
+esp-idf-hal = { version = "0.40.1", features = [
+    "default",
+    "embassy-sync",
+    "critical-section",
+    "edge-executor"
+]}
 esp-idf-svc = { version = "0.45.0", features = [
     "std",
     "nightly",

--- a/cargo/Cargo.toml
+++ b/cargo/Cargo.toml
@@ -17,9 +17,20 @@ pio = ["esp-idf-sys/pio"]
 
 [dependencies]
 {% if std %}esp-idf-sys = { version = "0.32.1", features = ["binstart"] }
-{% if hal %}
+{% if hal == "Yes (default features)" %}
 esp-idf-hal = { version = "0.40.1"}
 esp-idf-svc = { version = "0.45.0"}
+{% endif %} 
+{% if hal == "Yes (all features)" %}
+esp-idf-hal = { version = "0.40.1", features = ["default","embassy-sync","critical-section","edge-executor"]}
+esp-idf-svc = { version = "0.45.0", features = [
+    "std",
+    "nightly",
+    "experimental",
+    "embassy-time-driver",
+    "embassy-time-isr-queue",
+    "alloc"
+]}
 {% endif %} 
 {% else %}log = { version = "0.4.17", default-features = false }
 esp-idf-sys = { version = "0.32.1", default-features = false, features = ["binstart", "panic_handler", "alloc_handler"] }

--- a/cargo/Cargo.toml
+++ b/cargo/Cargo.toml
@@ -20,6 +20,9 @@ pio = ["esp-idf-sys/pio"]
 {% else %}log = { version = "0.4.17", default-features = false }
 esp-idf-sys = { version = "0.32.1", default-features = false, features = ["binstart", "panic_handler", "alloc_handler"] }
 esp-idf-svc = { version = "0.45.0", default-features = false, features = ["alloc"] }{% endif %}
-
+{% if hal %}
+esp-idf-hal ={ version = "0.40.1"}
+esp-idf-svc ={ version = "0.45.0"}
+{% endif %} 
 [build-dependencies]
 embuild = "0.31.1"

--- a/cargo/Cargo.toml
+++ b/cargo/Cargo.toml
@@ -18,8 +18,8 @@ pio = ["esp-idf-sys/pio"]
 [dependencies]
 {% if std %}esp-idf-sys = { version = "0.32.1", features = ["binstart"] }
 {% if hal %}
-esp-idf-hal ={ version = "0.40.1"}
-esp-idf-svc ={ version = "0.45.0"}
+esp-idf-hal = { version = "0.40.1"}
+esp-idf-svc = { version = "0.45.0"}
 {% endif %} 
 {% else %}log = { version = "0.4.17", default-features = false }
 esp-idf-sys = { version = "0.32.1", default-features = false, features = ["binstart", "panic_handler", "alloc_handler"] }

--- a/cargo/Cargo.toml
+++ b/cargo/Cargo.toml
@@ -17,12 +17,13 @@ pio = ["esp-idf-sys/pio"]
 
 [dependencies]
 {% if std %}esp-idf-sys = { version = "0.32.1", features = ["binstart"] }
-{% else %}log = { version = "0.4.17", default-features = false }
-esp-idf-sys = { version = "0.32.1", default-features = false, features = ["binstart", "panic_handler", "alloc_handler"] }
-esp-idf-svc = { version = "0.45.0", default-features = false, features = ["alloc"] }{% endif %}
 {% if hal %}
 esp-idf-hal ={ version = "0.40.1"}
 esp-idf-svc ={ version = "0.45.0"}
 {% endif %} 
+{% else %}log = { version = "0.4.17", default-features = false }
+esp-idf-sys = { version = "0.32.1", default-features = false, features = ["binstart", "panic_handler", "alloc_handler"] }
+esp-idf-svc = { version = "0.45.0", default-features = false, features = ["alloc"] }{% endif %}
+
 [build-dependencies]
 embuild = "0.31.1"

--- a/cargo/cargo-generate.toml
+++ b/cargo/cargo-generate.toml
@@ -11,7 +11,6 @@ mcu = { type = "string", prompt = "MCU", choices = [
     "esp32c3",
 ], default = "esp32" }
 std = { type = "bool", prompt = "STD support", default = true }
-hal = { type = "bool", prompt = "Include esp-idf-hal/svc ?", default = true}
 espidfver = { type = "string", prompt = "ESP-IDF native build version (v4.3.2 = previous stable, v4.4 = stable, mainline = UNSTABLE)", choices = [
     "v4.4",
     "v4.3.2",
@@ -30,3 +29,6 @@ ignore = [
     "docs/",
     "scripts/",
 ]
+
+[conditional.'std == true'.placeholders]
+hal = { type = "bool", prompt = "Include esp-idf-hal/svc ?", default = true}

--- a/cargo/cargo-generate.toml
+++ b/cargo/cargo-generate.toml
@@ -11,6 +11,7 @@ mcu = { type = "string", prompt = "MCU", choices = [
     "esp32c3",
 ], default = "esp32" }
 std = { type = "bool", prompt = "STD support", default = true }
+hal = { type = "bool", prompt = "Include esp-idf-hal/svc ?", default = true}
 espidfver = { type = "string", prompt = "ESP-IDF native build version (v4.3.2 = previous stable, v4.4 = stable, mainline = UNSTABLE)", choices = [
     "v4.4",
     "v4.3.2",

--- a/cargo/cargo-generate.toml
+++ b/cargo/cargo-generate.toml
@@ -31,4 +31,8 @@ ignore = [
 ]
 
 [conditional.'std == true'.placeholders]
-hal = { type = "bool", prompt = "Include esp-idf-hal/svc ?", default = true}
+hal = { type = "string", prompt = "Include esp-idf-hal/svc ?", choices = [
+    "No",
+    "Yes (default features)",
+    "Yes (all features)",
+], default = "Yes (default features)"}


### PR DESCRIPTION
I think most people want also esp-idf-hal / svc crate when generating an std template. This PR adds the option to generate them only when selecting the std option + gives 3 option [No, default option, all options] 