### PR TITLE
Rename esp-idf option from mainline to master

### DIFF
--- a/.github/workflows/ci_cargo.yml
+++ b/.github/workflows/ci_cargo.yml
@@ -38,7 +38,7 @@ jobs:
           - version: release/v5.0
             name: v5.0
           # - version: master
-          #   name: mainline
+          #   name: master
     steps:
       - name: Setup | Rust (RISC-V)
         if: matrix.target != 'esp32' && matrix.target != 'esp32s2' && matrix.target != 'esp32s3'

--- a/.github/workflows/ci_cmake.yml
+++ b/.github/workflows/ci_cmake.yml
@@ -46,7 +46,7 @@ jobs:
           - version: release/v5.0
             name: v5.0
           # - version: master
-          #   name: mainline
+          #   name: master
     steps:
       - name: Setup | Rust (RISC-V)
         if: matrix.target.board != 'esp32' && matrix.target.board != 'esp32s2' && matrix.target.board != 'esp32s3'

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The command will display a few prompts:
   - `ESP-IDF Version`: ESP-IDF branch/tag to use. Possible choices:
     - [`v4.4`](https://github.com/espressif/esp-idf/tree/release/v4.4): Stable
     - [`v5.0`](https://github.com/espressif/esp-idf/tree/release/v5.0): Stable
-    - [`mainline`](https://github.com/espressif/esp-idf/tree/master): **Unstable**
+    - [`master`](https://github.com/espressif/esp-idf/tree/master): **Unstable**
    - `Configure project to support Wokwi simulation with Wokwi VS Code extension?`: Adds support for Wokwi simulation using [VS Code Wokwi extension](https://marketplace.visualstudio.com/items?itemName=wokwi.wokwi-vscode).
   - `Configure project to use Dev Containers (VS Code and GitHub Codespaces)?`: Adds support for:
       -  [VS Code Dev Containers](https://code.visualstudio.com/docs/remote/containers#_quick-start-open-an-existing-folder-in-a-container)

--- a/cargo/.cargo/config.toml
+++ b/cargo/.cargo/config.toml
@@ -26,6 +26,6 @@ build-std = ["core", "alloc", "panic_abort"]
 ESP_IDF_VERSION = "release/v4.4"
 {% elsif espidfver == "v5.0" %}
 ESP_IDF_VERSION = "release/v5.0"
-{% elsif espidfver == "mainline" %}
+{% elsif espidfver == "master" %}
 ESP_IDF_VERSION = "master"
 {% endif %}

--- a/cargo/cargo-generate.toml
+++ b/cargo/cargo-generate.toml
@@ -23,8 +23,8 @@ default = true
 
 [conditional.'defaults == false'.placeholders.espidfver]
 type = "string"
-prompt = "ESP-IDF version (mainline = UNSTABLE)"
-choices = ["v4.4", "v5.0", "mainline"]
+prompt = "ESP-IDF version (master = UNSTABLE)"
+choices = ["v4.4", "v5.0", "master"]
 default = "v4.4"
 
 [conditional.'defaults == false'.placeholders.devcontainer]


### PR DESCRIPTION
As suggested by @Vollbrecht, we are renaming the esp-idf option from `mainline` to `master` to be consisten with the naming