### PR TITLE
add esp32c6

### DIFF
--- a/cargo/cargo-generate.toml
+++ b/cargo/cargo-generate.toml
@@ -8,7 +8,7 @@ pre = ["pre-script.rhai"]
 [placeholders.mcu]
 type = "string"
 prompt = "Which MCU to target?"
-choices = ["esp32", "esp32c3", "esp32s2", "esp32s3"]
+choices = ["esp32", "esp32c3", "esp32s2", "esp32s3", "esp32c6"]
 default = "esp32"
 
 [placeholders.defaults]

--- a/cargo/cargo-generate.toml
+++ b/cargo/cargo-generate.toml
@@ -8,7 +8,7 @@ pre = ["pre-script.rhai"]
 [placeholders.mcu]
 type = "string"
 prompt = "Which MCU to target?"
-choices = ["esp32", "esp32c3", "esp32s2", "esp32s3", "esp32c6"]
+choices = ["esp32", "esp32c3", "esp32s2", "esp32s3", "esp32c6", "esp32c2", "esp32h2"]
 default = "esp32"
 
 [placeholders.defaults]

--- a/cargo/pre-script.rhai
+++ b/cargo/pre-script.rhai
@@ -23,6 +23,24 @@ let targets = #{
         gcc_target: "riscv32-esp-elf",
         wokwi_board: "board-esp32-c3-devkitm-1",
     },
+    esp32c6: #{
+        arch: "riscv",
+        rust_target: "riscv32imc-esp-espidf",
+        gcc_target: "risvc32-esp-elf",
+        wokwi_board: "board-esp32-c6-devkitm-1",
+    },
+    esp32c2: #{
+        arch: "riscv",
+        rust_target: "riscv32imc-esp-espidf",
+        gcc_target: "risvc32-esp-elf",
+        wokwi_board: "board-esp32-c6-devkitm-1",
+    },
+    esp32h2: #{
+        arch: "riscv",
+        rust_target: "riscv32imc-esp-espidf",
+        gcc_target: "risvc32-esp-elf",
+        wokwi_board: "board-esp32-c6-devkitm-1",
+    }
 };
 
 let target = variable::get("mcu");


### PR DESCRIPTION
Adds the options for the esp32 c6 dev board in the cargo generate toml
