### PR TITLE
Update template for new chips

### DIFF
--- a/.github/workflows/ci_cargo.yml
+++ b/.github/workflows/ci_cargo.yml
@@ -36,8 +36,8 @@ jobs:
         esp-idf:
           - version: release/v4.4
             name: v4.4
-          - version: release/v5.0
-            name: v5.0
+          - version: release/v5.1
+            name: v5.1
           # - version: master
           #   name: master
     steps:

--- a/.github/workflows/ci_cargo.yml
+++ b/.github/workflows/ci_cargo.yml
@@ -18,13 +18,85 @@ env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 jobs:
-  cargo-checks:
+  cargo-checks-v5:
     name: "${{ matrix.target }} | ${{ matrix.esp-idf.name }} | std(hal):${{ matrix.std-config.std }}(${{ matrix.std-config.hal }})"
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        target: ["esp32", "esp32s2", "esp32s3", "esp32c3"]
+        target: ["esp32", "esp32c3", esp32c2, esp32c6, esp32h2, "esp32s2", "esp32s3"]
+        std-config:
+          - std: false
+          - std: true
+            hal: "No"
+          - std: true
+            hal: "Yes (default features)"
+          - std: true
+            hal: "Yes (all features)"
+        esp-idf:
+          - version: release/v5.1
+            name: v5.1
+          - version: master
+            name: master
+    steps:
+      - name: Setup | Rust (RISC-V)
+        if: matrix.target != 'esp32' && matrix.target != 'esp32s2' && matrix.target != 'esp32s3'
+        uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: nightly
+          components: clippy, rustfmt, rust-src
+      - name: Setup | Rust (Xtensa)
+        if: matrix.target == 'esp32' || matrix.target == 'esp32s2' || matrix.target == 'esp32s3'
+        uses: esp-rs/xtensa-toolchain@v1.5.1
+        with:
+          default: true
+          buildtargets: ${{ matrix.target }}
+          ldproxy: false
+      - uses: Swatinem/rust-cache@v2
+      - name: Setup | cargo-generate (binary)
+        id: cargo-generate-binary
+        continue-on-error: true
+        run: |
+          sudo curl -L "https://github.com/cargo-generate/cargo-generate/releases/latest/download/cargo-generate-$(git ls-remote --refs --sort="version:refname" --tags "https://github.com/cargo-generate/cargo-generate" | cut -d/ -f3- | tail -n1)-x86_64-unknown-linux-gnu.tar.gz" -o "/home/runner/.cargo/bin/cargo-generate.tar.gz"
+          tar xf "/home/runner/.cargo/bin/cargo-generate.tar.gz" -C /home/runner/.cargo/bin
+          chmod u+x /home/runner/.cargo/bin/cargo-generate
+      - name: Setup | cargo-generate (cargo)
+        if: steps.cargo-generate-binary.outcome != 'success'
+        run: cargo install cargo-generate
+      - name: Setup | ldproxy (binary)
+        id: ldproxy-binary
+        continue-on-error: true
+        run: |
+          sudo curl -L "https://github.com/esp-rs/embuild/releases/latest/download/ldproxy-x86_64-unknown-linux-gnu.zip" -o "/home/runner/.cargo/bin/ldproxy.zip"
+          unzip "/home/runner/.cargo/bin/ldproxy.zip" -d "/home/runner/.cargo/bin/"
+          chmod u+x /home/runner/.cargo/bin/ldproxy
+      - name: Setup | ldproxy (cargo)
+        if: steps.ldproxy-binary.outcome != 'success'
+        run: cargo install ldproxy
+      - uses: actions/checkout@v3
+        with:
+          path: /home/runner/work/esp-idf-template/esp-idf-template/github-esp-idf-template
+      - name: Generate (STD)
+        if: matrix.std-config.std == true
+        run: cargo generate --path /home/runner/work/esp-idf-template/esp-idf-template/github-esp-idf-template cargo --name test --vcs none --silent -d mcu=${{ matrix.target }} -d defaults=false -d espidfver=${{ matrix.esp-idf.name }} -d std=${{ matrix.std-config.std }} -d hal="${{ matrix.std-config.hal }}" -d devcontainer=false -d wokwi=false
+      - name: Generate (No STD)
+        if: matrix.std-config.std == false
+        run: cargo generate --path /home/runner/work/esp-idf-template/esp-idf-template/github-esp-idf-template cargo --name test --vcs none --silent -d mcu=${{ matrix.target }} -d defaults=false -d espidfver=${{ matrix.esp-idf.name }} -d std=${{ matrix.std-config.std }} -d devcontainer=false -d wokwi=false
+      - name: Build | Fmt Check (RISC-V)
+        if: matrix.target != 'esp32' && matrix.target != 'esp32s2' && matrix.target != 'esp32s3'
+        run: cd test; cargo fmt -- --check
+      - name: Build | Clippy (RISC-V)
+        if: matrix.target != 'esp32' && matrix.target != 'esp32s2' && matrix.target != 'esp32s3'
+        run: cd test; cargo clippy --no-deps -- -Dwarnings
+      - name: Build | Compile
+        run: cd test; cargo build
+cargo-checks-v4:
+    name: "${{ matrix.target }} | ${{ matrix.esp-idf.name }} | std(hal):${{ matrix.std-config.std }}(${{ matrix.std-config.hal }})"
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        target: ["esp32", "esp32c3", "esp32s2", "esp32s3"]
         std-config:
           - std: false
           - std: true
@@ -36,10 +108,6 @@ jobs:
         esp-idf:
           - version: release/v4.4
             name: v4.4
-          - version: release/v5.1
-            name: v5.1
-          # - version: master
-          #   name: master
     steps:
       - name: Setup | Rust (RISC-V)
         if: matrix.target != 'esp32' && matrix.target != 'esp32s2' && matrix.target != 'esp32s3'

--- a/.github/workflows/ci_cargo.yml
+++ b/.github/workflows/ci_cargo.yml
@@ -90,7 +90,7 @@ jobs:
         run: cd test; cargo clippy --no-deps -- -Dwarnings
       - name: Build | Compile
         run: cd test; cargo build
-cargo-checks-v4:
+  cargo-checks-v4:
     name: "${{ matrix.target }} | ${{ matrix.esp-idf.name }} | std(hal):${{ matrix.std-config.std }}(${{ matrix.std-config.hal }})"
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/ci_cmake.yml
+++ b/.github/workflows/ci_cmake.yml
@@ -44,8 +44,8 @@ jobs:
         esp-idf:
           - version: release/v4.4
             name: v4.4
-          - version: release/v5.0
-            name: v5.0
+          - version: release/v5.1
+            name: v5.1
           # - version: master
           #   name: master
     steps:

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The command will display a few prompts:
   - `Enable STD support?`: When `true` (default), adds support for the [Rust Standard Library](https://doc.rust-lang.org/std/). Otherwise, a `no_std` [Rust Core Library](https://doc.rust-lang.org/core/index.html) crate would be created.
   - `ESP-IDF Version`: ESP-IDF branch/tag to use. Possible choices:
     - [`v4.4`](https://github.com/espressif/esp-idf/tree/release/v4.4): Stable
-    - [`v5.0`](https://github.com/espressif/esp-idf/tree/release/v5.0): Stable
+    - [`v5.1`](https://github.com/espressif/esp-idf/tree/release/v5.1): Stable
     - [`master`](https://github.com/espressif/esp-idf/tree/master): **Unstable**
    - `Configure project to support Wokwi simulation with Wokwi VS Code extension?`: Adds support for Wokwi simulation using [VS Code Wokwi extension](https://marketplace.visualstudio.com/items?itemName=wokwi.wokwi-vscode).
   - `Configure project to use Dev Containers (VS Code and GitHub Codespaces)?`: Adds support for:

--- a/cargo/.cargo/config.toml
+++ b/cargo/.cargo/config.toml
@@ -24,8 +24,8 @@ build-std = ["core", "alloc", "panic_abort"]
 # Note: these variables are not used when using pio builder (`cargo build --features pio`)
 {%- if espidfver == "v4.4" %}
 ESP_IDF_VERSION = "release/v4.4"
-{% elsif espidfver == "v5.0" %}
-ESP_IDF_VERSION = "release/v5.0"
+{% elsif espidfver == "v5.1" %}
+ESP_IDF_VERSION = "release/v5.1"
 {% elsif espidfver == "master" %}
 ESP_IDF_VERSION = "master"
 {% endif %}

--- a/cargo/cargo-generate.toml
+++ b/cargo/cargo-generate.toml
@@ -8,7 +8,7 @@ pre = ["pre-script.rhai"]
 [placeholders.mcu]
 type = "string"
 prompt = "Which MCU to target?"
-choices = ["esp32", "esp32c3", "esp32s2", "esp32s3", "esp32c6", "esp32c2", "esp32h2", "esp32p4"]
+choices = ["esp32", "esp32c2", "esp32c3", "esp32c6", "esp32h2", "esp32s2", "esp32s3"]
 default = "esp32"
 
 [placeholders.defaults]
@@ -16,46 +16,46 @@ type = "bool"
 prompt = "Use the default template values?"
 default = true
 
-[conditional.'defaults == false'.placeholders.std]
+[conditional.'!defaults'.placeholders.std]
 type = "bool"
 prompt = "Enable STD support?"
 default = true
 
-[conditional.'defaults == false && (mcu == "esp32c6" || mcu == "esp32p4" || mcu == "esp32h2")'.placeholders.espidfver]
+[conditional.'!defaults && (mcu == "esp32c6" || mcu == "esp32h2")'.placeholders.espidfver]
 type = "string"
 prompt = "ESP-IDF version (master = UNSTABLE)"
 choices = ["master"] # Supported as of v5.1
 default = "master"
 
-[conditional.'defaults == false && (mcu == "esp32c2")'.placeholders.espidfver]
+[conditional.'!defaults && (mcu == "esp32c2")'.placeholders.espidfver]
 type = "string"
 prompt = "ESP-IDF version (master = UNSTABLE)"
 choices = ["v5.0", "master"]
 default = "v5.0"
 
-[conditional.'defaults == false && (mcu == "esp32" || mcu == "esp32c3" || mcu == "esp32s2" || mcu == "esp32s3")'.placeholders.espidfver]
+[conditional.'!defaults && (mcu == "esp32" || mcu == "esp32c3" || mcu == "esp32s2" || mcu == "esp32s3")'.placeholders.espidfver]
 type = "string"
 prompt = "ESP-IDF version (master = UNSTABLE)"
 choices = ["v4.4", "v5.0", "master"]
 default = "v4.4"
 
-[conditional.'defaults == false'.placeholders.devcontainer]
+[conditional.'!defaults'.placeholders.devcontainer]
 type = "bool"
 prompt = "Configure project to use Dev Containers (VS Code and GitHub Codespaces)?"
 default = false
 
-[conditional.'defaults == false'.placeholders.wokwi]
+[conditional.'!defaults'.placeholders.wokwi]
 type = "bool"
 prompt = "Configure project to support Wokwi simulation with Wokwi VS Code extension?"
 default = false
 
-[conditional.'std == true'.placeholders.hal]
+[conditional.'!std'.placeholders.hal]
 type = "string"
 prompt = "Include esp-idf-hal/esp-idf-svc?"
 choices = ["No", "Yes (default features)", "Yes (all features)"]
 default = "Yes (default features)"
 
-[conditional.'devcontainer == false']
+[conditional.'!devcontainer']
 ignore = [
     ".devcontainer/",
     ".vscode/tasks.json",
@@ -64,10 +64,10 @@ ignore = [
     "scripts/",
 ]
 
-[conditional.'wokwi == false']
+[conditional.'!wokwi']
 ignore = [".vscode/launch.json", "diagram.json", "wokwi.toml"]
 
-[conditional.'defaults == true']
+[conditional.'defaults']
 ignore = [
     ".devcontainer/",
     ".vscode/",

--- a/cargo/cargo-generate.toml
+++ b/cargo/cargo-generate.toml
@@ -30,13 +30,13 @@ default = "master"
 [conditional.'!defaults && (mcu == "esp32c2")'.placeholders.espidfver]
 type = "string"
 prompt = "ESP-IDF version (master = UNSTABLE)"
-choices = ["v5.0", "master"]
-default = "v5.0"
+choices = ["v5.1", "master"]
+default = "v5.1"
 
 [conditional.'!defaults && (mcu == "esp32" || mcu == "esp32c3" || mcu == "esp32s2" || mcu == "esp32s3")'.placeholders.espidfver]
 type = "string"
 prompt = "ESP-IDF version (master = UNSTABLE)"
-choices = ["v4.4", "v5.0", "master"]
+choices = ["v4.4", "v5.1", "master"]
 default = "v4.4"
 
 [conditional.'!defaults'.placeholders.devcontainer]

--- a/cargo/cargo-generate.toml
+++ b/cargo/cargo-generate.toml
@@ -21,13 +21,7 @@ type = "bool"
 prompt = "Enable STD support?"
 default = true
 
-[conditional.'!defaults && (mcu == "esp32c6" || mcu == "esp32h2")'.placeholders.espidfver]
-type = "string"
-prompt = "ESP-IDF version (master = UNSTABLE)"
-choices = ["master"] # Supported as of v5.1
-default = "master"
-
-[conditional.'!defaults && (mcu == "esp32c2")'.placeholders.espidfver]
+[conditional.'!defaults && (mcu == "esp32c6" || mcu == "esp32h2" || mcu == "esp32c2")'.placeholders.espidfver]
 type = "string"
 prompt = "ESP-IDF version (master = UNSTABLE)"
 choices = ["v5.1", "master"]

--- a/cargo/cargo-generate.toml
+++ b/cargo/cargo-generate.toml
@@ -49,7 +49,7 @@ type = "bool"
 prompt = "Configure project to support Wokwi simulation with Wokwi VS Code extension?"
 default = false
 
-[conditional.'!std'.placeholders.hal]
+[conditional.'std'.placeholders.hal]
 type = "string"
 prompt = "Include esp-idf-hal/esp-idf-svc?"
 choices = ["No", "Yes (default features)", "Yes (all features)"]

--- a/cargo/pre-script.rhai
+++ b/cargo/pre-script.rhai
@@ -5,17 +5,11 @@ let targets = #{
         gcc_target: "xtensa-esp32-elf",
         wokwi_board: "board-esp32-devkit-v1",
     },
-    esp32s2: #{
-        arch: "xtensa",
-        rust_target: "xtensa-esp32s2-espidf",
-        gcc_target: "xtensa-esp32s2-elf",
-        wokwi_board: "board-esp32-s2-devkitm-1",
-    },
-    esp32s3: #{
-        arch: "xtensa",
-        rust_target: "xtensa-esp32s3-espidf",
-        gcc_target: "xtensa-esp32s3-elf",
-        wokwi_board: "board-esp32-s3-devkitc-1",
+    esp32c2: #{
+        arch: "riscv",
+        rust_target: "riscv32imc-esp-espidf",
+        gcc_target: "riscv32-esp-elf",
+        wokwi_board: "board-esp32-c6-devkitm-1",
     },
     esp32c3: #{
         arch: "riscv",
@@ -29,23 +23,23 @@ let targets = #{
         gcc_target: "riscv32-esp-elf",
         wokwi_board: "board-esp32-c6-devkitm-1",
     },
-    esp32c2: #{
-        arch: "riscv",
-        rust_target: "riscv32imc-esp-espidf",
-        gcc_target: "risvc32-esp-elf",
-        wokwi_board: "board-esp32-c6-devkitm-1",
-    },
     esp32h2: #{
-        arch: "riscv",
-        rust_target: "riscv32imc-esp-espidf",
-        gcc_target: "risvc32-esp-elf",
-        wokwi_board: "board-esp32-c6-devkitm-1",
-    },
-    esp32p4: #{
         arch: "riscv",
         rust_target: "riscv32imac-esp-espidf",
         gcc_target: "riscv32-esp-elf",
         wokwi_board: "board-esp32-c6-devkitm-1",
+    },
+    esp32s2: #{
+        arch: "xtensa",
+        rust_target: "xtensa-esp32s2-espidf",
+        gcc_target: "xtensa-esp32s2-elf",
+        wokwi_board: "board-esp32-s2-devkitm-1",
+    },
+    esp32s3: #{
+        arch: "xtensa",
+        rust_target: "xtensa-esp32s3-espidf",
+        gcc_target: "xtensa-esp32s3-elf",
+        wokwi_board: "board-esp32-s3-devkitc-1",
     },
 };
 

--- a/cargo/pre-script.rhai
+++ b/cargo/pre-script.rhai
@@ -9,7 +9,7 @@ let targets = #{
         arch: "riscv",
         rust_target: "riscv32imc-esp-espidf",
         gcc_target: "riscv32-esp-elf",
-        wokwi_board: "board-esp32-c6-devkitm-1",
+        wokwi_board: "",
     },
     esp32c3: #{
         arch: "riscv",
@@ -27,7 +27,7 @@ let targets = #{
         arch: "riscv",
         rust_target: "riscv32imac-esp-espidf",
         gcc_target: "riscv32-esp-elf",
-        wokwi_board: "board-esp32-c6-devkitm-1",
+        wokwi_board: "",
     },
     esp32s2: #{
         arch: "xtensa",
@@ -52,7 +52,12 @@ for key in target_properties.keys() {
 let defaults = variable::get("defaults");
 if defaults {
     variable::set("std", true);
-    variable::set("espidfver", "v4.4");
+    if target == "esp32" || target == "esp32s2" || target == "esp32s3" || target == "esp32c3" {
+        variable::set("espidfver", "v4.4");
+    }
+    else {
+        variable::set("espidfver", "v5.1");
+    }
     variable::set("devcontainer", false);
     variable::set("wokwi", false);
     variable::set("hal", "Yes (default features)");


### PR DESCRIPTION
- Remove esp32p4 target
  - Is not supported yet, and we don't know when it will be released
- Update and simplify the conditions of the placeholders
- Replaced v5.0 for 5.1 (see #121)
- Expand CI to cover new targets
  - CI is failing for `v5.1` since the [following cfg](https://github.com/esp-rs/esp-idf-hal/blob/master/src/ledc.rs#L129-L134) needs to be adjusted.
- Updated the default values for new chips.

The PR updates the changes introduced in #123, #124 #125