### PR TITLE
Add note about CARGO_WORKSPACE_DIR must be set if CARGO_TARGET_DIR is

### DIFF
--- a/cargo/.cargo/config.toml
+++ b/cargo/.cargo/config.toml
@@ -29,3 +29,7 @@ ESP_IDF_VERSION = "release/v5.1"
 {% elsif espidfver == "master" %}
 ESP_IDF_VERSION = "master"
 {% endif %}
+
+# Uncomment this if you have moved the target dir by setting CARGO_TARGET_DIR or similar.
+# Required for now due to embuild limitations.
+#CARGO_WORKSPACE_DIR = { value = "", relative = true }


### PR DESCRIPTION
Companion PR with https://github.com/esp-rs/esp-idf-sys/pull/221. This caveat makes me waste a lot of time every time I get into ESP programming. I don't know how common it is in general to set `CARGO_TARGET_DIR`, but I have it set to `~/.cargo/target` all the time. And `embuild` does not like this.