### PR TITLE
Remove Cargo.lock from gitignore

### DIFF
--- a/cargo/.gitignore
+++ b/cargo/.gitignore
@@ -1,4 +1,3 @@
 /.vscode
 /.embuild
 /target
-/Cargo.lock


### PR DESCRIPTION
I think it should be version controlled since it's a binary project, not a library.