### PR TITLE
[nits] Make ldproxy to true in rust_ci.yml

### DIFF
--- a/cargo/.github/workflows/rust_ci.yml
+++ b/cargo/.github/workflows/rust_ci.yml
@@ -43,7 +43,7 @@ jobs:
         with:
           default: true
           buildtargets: {{ mcu }}
-          ldproxy: false
+          ldproxy: true
       {%- endif %}
       - name: Run command
         {%- raw %}


### PR DESCRIPTION
## What

Set `true` to ldproxy in rust_ci.yml

## Why

As described in https://github.com/esp-rs/xtensa-toolchain#inputs , `ldproxy` property should be `true` if want to use std. So set it to `true` because this template is for using std with esp.
Actually, rust_ci fails because `ldproxy` not found in my environment.
https://github.com/ysak-y/test-esp-idf-rust/actions/runs/6214217169/job/16865945339

## How

Set `ldproxy` property to true.

Could you please review this? @SergioGasquez 