### PR TITLE
🔖 bump esp-idf tags

### DIFF
--- a/cargo/.cargo/config.toml
+++ b/cargo/.cargo/config.toml
@@ -23,9 +23,9 @@ build-std = ["core", "alloc", "panic_abort"]
 [env]
 # Note: these variables are not used when using pio builder (`cargo build --features pio`)
 {%- if espidfver == "v4.4" %}
-ESP_IDF_VERSION = "v4.4.5"
+ESP_IDF_VERSION = "v4.4.6"
 {% elsif espidfver == "v5.1" %}
-ESP_IDF_VERSION = "v5.1"
+ESP_IDF_VERSION = "v5.1.1"
 {% elsif espidfver == "master" %}
 ESP_IDF_VERSION = "master"
 {% endif %}


### PR DESCRIPTION
To install the  correct upstream esp-idf version the env variables need to point to the full version tag.

Note: ESP_IDF_VERSION "v5.1" is a different release than "v5.1.1" 

Release Notes:
v4.4.6 https://github.com/espressif/esp-idf/releases/tag/v4.4.6
v5.1.1https://github.com/espressif/esp-idf/releases/tag/v5.1.1
