### PR TITLE
🐛 add missing TX for terminal output

### DIFF
--- a/cargo/diagram.json
+++ b/cargo/diagram.json
@@ -15,6 +15,7 @@
     ],
     "connections": [
         [
+            "esp:TX",
             "$serialMonitor:RX",
             "",
             []


### PR DESCRIPTION
needed for correct terminal output in wokwi