### PR TITLE
Fix c6 wokwi board component

### DIFF
--- a/cargo/pre-script.rhai
+++ b/cargo/pre-script.rhai
@@ -21,7 +21,7 @@ let targets = #{
         arch: "riscv",
         rust_target: "riscv32imac-esp-espidf",
         gcc_target: "riscv32-esp-elf",
-        wokwi_board: "board-esp32-c6-devkitm-1",
+        wokwi_board: "board-esp32-c6-devkitc-1",
     },
     esp32h2: #{
         arch: "riscv",


### PR DESCRIPTION
The wokwi_board was incorrect for esc32-c6. See https://github.com/wokwi/wokwi-features/issues/751