### PR TITLE
Add workaround for #174, cc crate failing on macOS

### DIFF
--- a/cargo/.cargo/config.toml
+++ b/cargo/.cargo/config.toml
@@ -28,3 +28,7 @@ ESP_IDF_VERSION = "v5.1.3"
 {% elsif espidfver == "master" %}
 ESP_IDF_VERSION = "master"
 {% endif %}
+# Workaround for https://github.com/esp-rs/esp-idf-template/issues/174 until
+# https://github.com/esp-rs/esp-idf-hal/pull/387 gets released and the template
+# updated.
+CRATE_CC_NO_DEFAULTS = "1"


### PR DESCRIPTION
I've hit this trap several times during the last weeks. #174 describes it and the solution. But every time I hit it, I just had forgotten about it which was quite annoying.

The workaround apparently does not affect Linux (while I can't test on Windows). So why not shipping it until https://github.com/esp-rs/esp-idf-hal/pull/387 gets released and the template updated?