### PR TITLE
do not use the built in cargo test harness for bin targets

### DIFF
--- a/cargo/Cargo.toml
+++ b/cargo/Cargo.toml
@@ -6,6 +6,10 @@ edition = "2021"
 resolver = "2"
 rust-version = "1.71"
 
+[[bin]]
+name = "{{project-name}}"
+harness = false # do not use the built in cargo test harneess -> resolve rust-analyzer errors
+
 [profile.release]
 opt-level = "s"
 

--- a/cargo/Cargo.toml
+++ b/cargo/Cargo.toml
@@ -8,7 +8,7 @@ rust-version = "1.71"
 
 [[bin]]
 name = "{{project-name}}"
-harness = false # do not use the built in cargo test harneess -> resolve rust-analyzer errors
+harness = false # do not use the built in cargo test harness -> resolve rust-analyzer errors
 
 [profile.release]
 opt-level = "s"


### PR DESCRIPTION
introduces a workaround so people by default have a working rust-analyzer that doesn't trip over building tests for the bin crate.
RA fails over this with problems that lead to problems mention upstream https://github.com/rust-lang/rust/issues/125714