### PR TITLE
Add mount for host's udev rules in container

### DIFF
--- a/cargo/.devcontainer/devcontainer.json
+++ b/cargo/.devcontainer/devcontainer.json
@@ -10,6 +10,11 @@
       "ESP_BOARD": "{{ mcu }}"
     }
   },
+  // https://github.com/serialport/serialport-rs/issues/153
+  "runArgs": [
+    "--mount",
+    "type=bind,source=/run/udev,target=/run/udev,readonly"
+  ],
   "customizations": {
     "vscode": {
       "settings": {


### PR DESCRIPTION
This is done to address a problem in the `serialport-rs` library: https://github.com/serialport/serialport-rs/issues/153
Without this fix, `espflash` is unable to see my board's `ttyACM` node

I'm using the `runArgs` property since the `mounts` property doesn't allow specifying `readonly`.