### PR TITLE
Radically simplify the generated Cargo.toml

### DIFF
--- a/.github/workflows/ci_cargo.yml
+++ b/.github/workflows/ci_cargo.yml
@@ -21,7 +21,7 @@ env:
 
 jobs:
   checks:
-    name: "${{ matrix.target }} | ${{ matrix.esp-idf.version }}
+    name: "${{ matrix.target }} | ${{ matrix.esp-idf.version }}"
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/ci_cargo.yml
+++ b/.github/workflows/ci_cargo.yml
@@ -21,15 +21,12 @@ env:
 
 jobs:
   checks:
-    name: "${{ matrix.target }} | ${{ matrix.esp-idf.version }} | std=${{ matrix.std-config.std }}"
+    name: "${{ matrix.target }} | ${{ matrix.esp-idf.version }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         target: ["esp32", "esp32c3", "esp32c2", "esp32c6", "esp32h2", "esp32s2", "esp32s3"]
-        std-config:
-          - std: true
-          - std: false
         esp-idf:
           - version: v5.2
           - version: v5.1 # only for compairson why no_std build fails on v5.2
@@ -74,16 +71,16 @@ jobs:
           path: /home/runner/work/esp-idf-template/esp-idf-template/github-esp-idf-template
       - name: Generate v5.2
         if: matrix.esp-idf.version == 'v5.2' || matrix.esp-idf.version == 'v5.1'
-        run: cargo generate --path /home/runner/work/esp-idf-template/esp-idf-template/github-esp-idf-template cargo --name ${{ matrix.target }}-${{ matrix.std-config.std }}  --vcs none --silent -d mcu=${{ matrix.target }} -d advanced=true -d espidfver=${{ matrix.esp-idf.version }} -d std=${{ matrix.std-config.std }} -d devcontainer=false -d wokwi=false -d ci=false
+        run: cargo generate --path /home/runner/work/esp-idf-template/esp-idf-template/github-esp-idf-template cargo --name ${{ matrix.target }} --vcs none --silent -d mcu=${{ matrix.target }} -d espidfver=${{ matrix.esp-idf.version }} -d devcontainer=false -d wokwi=false -d ci=false
       - name: Build | Fmt Check
         if: matrix.esp-idf.version == 'v5.2' && matrix.target == 'esp32c3'
-        run: cd ${{ matrix.target }}-${{ matrix.std-config.std }}; cargo fmt -- --check
+        run: cd ${{ matrix.target }}; cargo fmt -- --check
       - name: Build | Clippy
         if: matrix.esp-idf.version == 'v5.2' || matrix.esp-idf.version == 'v5.1'
-        run: cd ${{ matrix.target }}-${{ matrix.std-config.std }}; cargo clippy --no-deps -- -Dwarnings
+        run: cd ${{ matrix.target }}; cargo clippy --no-deps -- -Dwarnings
       - name: Build | Compile
         if: matrix.esp-idf.version == 'v5.2' || matrix.esp-idf.version == 'v5.1'
-        run: cd ${{ matrix.target }}-${{ matrix.std-config.std }}; cargo build
+        run: cd ${{ matrix.target }}; cargo build
   container-checks:
     name: "Container Check: ${{ matrix.target }}"
     runs-on: ubuntu-latest
@@ -109,7 +106,7 @@ jobs:
         with:
           path: /home/runner/work/esp-idf-template/esp-idf-template/github-esp-idf-template
       - name: Generate
-        run: cargo generate --path /home/runner/work/esp-idf-template/esp-idf-template/github-esp-idf-template cargo --name test-${{ matrix.target }} --vcs none --silent -d mcu=${{ matrix.target }} -d advanced=true -d espidfver=v5.2 -d std=true -d devcontainer=true -d wokwi=false -d ci=false
+        run: cargo generate --path /home/runner/work/esp-idf-template/esp-idf-template/github-esp-idf-template cargo --name test-${{ matrix.target }} --vcs none --silent -d mcu=${{ matrix.target }} -d espidfver=v5.2 -d devcontainer=true -d wokwi=false -d ci=false
       - name: Update ownership
         run: |
           sudo chown 1000:1000 -R test-${{ matrix.target }}

--- a/.github/workflows/ci_cargo.yml
+++ b/.github/workflows/ci_cargo.yml
@@ -71,7 +71,7 @@ jobs:
           path: /home/runner/work/esp-idf-template/esp-idf-template/github-esp-idf-template
       - name: Generate v5.2
         if: matrix.esp-idf.version == 'v5.2' || matrix.esp-idf.version == 'v5.1'
-        run: cargo generate --path /home/runner/work/esp-idf-template/esp-idf-template/github-esp-idf-template cargo --name ${{ matrix.target }} --vcs none --silent -d mcu=${{ matrix.target }} -d espidfver=${{ matrix.esp-idf.version }} -d devcontainer=false -d wokwi=false -d ci=false
+        run: cargo generate --path /home/runner/work/esp-idf-template/esp-idf-template/github-esp-idf-template cargo --name ${{ matrix.target }} --vcs none --silent -d mcu=${{ matrix.target }} -d advanced=true -d espidfver=${{ matrix.esp-idf.version }} -d devcontainer=false -d wokwi=false -d ci=false
       - name: Build | Fmt Check
         if: matrix.esp-idf.version == 'v5.2' && matrix.target == 'esp32c3'
         run: cd ${{ matrix.target }}; cargo fmt -- --check
@@ -106,7 +106,7 @@ jobs:
         with:
           path: /home/runner/work/esp-idf-template/esp-idf-template/github-esp-idf-template
       - name: Generate
-        run: cargo generate --path /home/runner/work/esp-idf-template/esp-idf-template/github-esp-idf-template cargo --name test-${{ matrix.target }} --vcs none --silent -d mcu=${{ matrix.target }} -d espidfver=v5.2 -d devcontainer=true -d wokwi=false -d ci=false
+        run: cargo generate --path /home/runner/work/esp-idf-template/esp-idf-template/github-esp-idf-template cargo --name test-${{ matrix.target }} --vcs none --silent -d mcu=${{ matrix.target }} -d advanced=true -d espidfver=v5.2 -d devcontainer=true -d wokwi=false -d ci=false
       - name: Update ownership
         run: |
           sudo chown 1000:1000 -R test-${{ matrix.target }}

--- a/.github/workflows/ci_cmake.yml
+++ b/.github/workflows/ci_cmake.yml
@@ -21,7 +21,7 @@ env:
 
 jobs:
   cmake-checks:
-    name: "${{ matrix.target.mcu }} | ${{ matrix.esp-idf.version }} | hal=${{ matrix.std-config.hal }} | std=${{ matrix.std-config.std }}"
+    name: "${{ matrix.target.mcu }} | ${{ matrix.esp-idf.version }}"
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -41,13 +41,6 @@ jobs:
             toolchain: "nightly"
           - mcu: "esp32h2"
             toolchain: "nightly"
-        std-config:
-          - hal: true
-            std: true
-          - hal: true
-            std: false
-          - hal: false
-            std: false
         esp-idf:
           - version: v5.2
           # - version: master
@@ -91,7 +84,7 @@ jobs:
         with:
           path: /home/runner/work/esp-idf-template/esp-idf-template/github-esp-idf-template
       - name: Generate
-        run: cargo generate --path /home/runner/work/esp-idf-template/esp-idf-template/github-esp-idf-template cmake --name test --vcs none --silent -d toolchain=${{ matrix.target.toolchain }} -d advanced=true -d hal=${{ matrix.std-config.hal }} -d std=${{ matrix.std-config.std }} -d espidfver=${{ matrix.esp-idf.version }}
+        run: cargo generate --path /home/runner/work/esp-idf-template/esp-idf-template/github-esp-idf-template cmake --name test --vcs none --silent -d toolchain=${{ matrix.target.toolchain }} -d espidfver=${{ matrix.esp-idf.version }}
       - name: ESP-IDF | Checkout
         run: git clone https://github.com/espressif/esp-idf; git -C esp-idf checkout ${{ matrix.esp-idf.version }}
       - name: ESP-IDF | Install Tooling

--- a/README-cmake-details.md
+++ b/README-cmake-details.md
@@ -218,7 +218,3 @@ Its important to note that we need to set the `WOKWI_CLI_TOKEN` secret:
 * [Add it as a secret in your GitHub repository](https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions).
 
 Also, the CI file needs to be modified if used for other targets.
-
-## Related Material
-
-[This repository](https://github.com/georgik/esp32-idf-no-std-rust-component) has a step-by-step guide, where you can create all project artefacts manually, without using `cargo generate`. It does emphasise specifically the creation of a Rust `no_std` and "no dependencies" ESP-IDF component, which is supported by the `esp-idf-template` generator as well, by selecting "advanced" options and then opting out of the "HAL" feature.

--- a/README-cmake.md
+++ b/README-cmake.md
@@ -12,11 +12,9 @@ If you would like to to understand how it works under the hood, read [this artic
 cargo generate --vcs none --git https://github.com/esp-rs/esp-idf-template cmake
 ```
 
-The command will display a few prompts:
+The command will display a couple of prompts:
   - `Project Name`: Name of the crate.
-  - `Rust toolchain`: Selects the `channel` in the [toolchain file](https://rust-lang.github.io/rustup/overrides.html#the-toolchain-file) to use. Select `esp` (the default). You can also select `nightly` if you are building for a RiscV ESP32 MCU
-  - (Advanced setup only) `HAL support`: When `true`, adds support for [calling into ESP-IDF and its components](https://github.com/esp-rs/esp-idf-svc)
-  - (Advanced setup only) `STD support`: When `true`, adds support for the [Rust Standard Library](https://doc.rust-lang.org/std/). Otherwise, we will use [Rust Core Library](https://doc.rust-lang.org/core/index.html).
+  - `Rust toolchain`: Selects the `channel` in the [toolchain file](https://rust-lang.github.io/rustup/overrides.html#the-toolchain-file) to use. Select `esp` (the default). You can also select `nightly` if you are building for a RiscV ESP32 MCU, though `esp` is always a safe choice.
 
 ## Enable ESP IDF components that you would like to use from Rust
 

--- a/README.md
+++ b/README.md
@@ -30,11 +30,11 @@ The command will display a few prompts:
 - `Project Name`: Name of the crate.
 - `Which MCU to target?`: SoC model, e.g. `esp32`, `esp32s2`, `esp32c3` etc.
 - `Configure advanced template options?`: If `false`, skips the rest of the prompts and uses their default value. If `true`, you will be prompted with:
-  - `Enable STD support?`: When `true` (default), adds support for the [Rust Standard Library](https://doc.rust-lang.org/std/). Otherwise, a `no_std` [Rust Core Library](https://doc.rust-lang.org/core/index.html) crate would be created.
   - `ESP-IDF Version`: ESP-IDF branch/tag to use. Possible choices:
     - [`v4.4`](https://github.com/espressif/esp-idf/releases/tag/v4.4.5): Stable
     - [`v5.1`](https://github.com/espressif/esp-idf/releases/tag/v5.1): Stable
-    - [`master`](https://github.com/espressif/esp-idf/tree/master): **Unstable**
+    - [`master`](https://github.com/espressif/esp-idf/tree/master): **Unstable**. Please do NOT choose the `master` ESP IDF version, unless you
+      really have a very good reason to. Building against ESP IDF `master` is NOT officially supported, and can break any time.
    - `Configure project to support Wokwi simulation with Wokwi VS Code extension?`: Adds support for Wokwi simulation using [VS Code Wokwi extension](https://marketplace.visualstudio.com/items?itemName=wokwi.wokwi-vscode).
   - `Configure project to use Dev Containers (VS Code and GitHub Codespaces)?`: Adds support for:
       -  [VS Code Dev Containers](https://code.visualstudio.com/docs/remote/containers#_quick-start-open-an-existing-folder-in-a-container)

--- a/cargo/.cargo/config.toml
+++ b/cargo/.cargo/config.toml
@@ -7,11 +7,7 @@ runner = "espflash flash --monitor" # Select this runner for espflash v3.x.x
 rustflags = [ "--cfg",  "espidf_time64"] # Extending time_t for ESP IDF 5: https://github.com/esp-rs/rust/issues/110
 
 [unstable]
-{% if std -%}
 build-std = ["std", "panic_abort"]
-{%- else -%}
-build-std = ["core", "alloc", "panic_abort"]
-{%- endif %}
 
 [env]
 MCU="{{ mcu }}"

--- a/cargo/Cargo.toml
+++ b/cargo/Cargo.toml
@@ -28,3 +28,4 @@ esp-idf-svc = { version = "0.49", features = ["critical-section", "embassy-time-
 
 [build-dependencies]
 embuild = "0.32.0"
+cc = "=1.1.30" # Necessary until a new version of `esp-idf-sys` is released

--- a/cargo/Cargo.toml
+++ b/cargo/Cargo.toml
@@ -18,22 +18,13 @@ debug = true    # Symbols are nice and they don't increase the size on Flash
 opt-level = "z"
 
 [features]
-{%- if std %}
-default = ["std", "embassy", "esp-idf-svc/native"]
-{%- else %}
-default = ["alloc", "embassy", "esp-idf-svc/native", "esp-idf-svc/panic_handler", "esp-idf-svc/alloc_handler", "esp-idf-svc/libstart"]
-{%- endif %}
+default = []
 
-pio = ["esp-idf-svc/pio"]
-std = ["alloc", "esp-idf-svc/binstart", "esp-idf-svc/std"]
-alloc = ["esp-idf-svc/alloc"]
-nightly = ["esp-idf-svc/nightly"]
 experimental = ["esp-idf-svc/experimental"]
-embassy = ["esp-idf-svc/embassy-sync", "esp-idf-svc/critical-section", "esp-idf-svc/embassy-time-driver"]
 
 [dependencies]
-log = { version = "0.4", default-features = false }
-esp-idf-svc = { version = "0.49", default-features = false }
+log = "0.4"
+esp-idf-svc = { version = "0.49", features = ["critical-section", "embassy-time-driver", "embassy-sync"] }
 
 [build-dependencies]
 embuild = "0.32.0"

--- a/cargo/cargo-generate.toml
+++ b/cargo/cargo-generate.toml
@@ -16,11 +16,6 @@ type = "bool"
 prompt = "Configure advanced template options?"
 default = false
 
-[conditional.'advanced'.placeholders.std]
-type = "bool"
-prompt = "Enable STD support?"
-default = true
-
 [conditional.'advanced'.placeholders.espidfver]
 type = "string"
 prompt = "ESP-IDF version (master = UNSTABLE)"

--- a/cargo/pre-script.rhai
+++ b/cargo/pre-script.rhai
@@ -51,7 +51,6 @@ for key in target_properties.keys() {
 
 let advanced = variable::get("advanced");
 if !advanced {
-    variable::set("std", true);
     variable::set("espidfver", "v5.2");
     variable::set("devcontainer", false);
     variable::set("wokwi", false);

--- a/cmake/cargo-generate.toml
+++ b/cmake/cargo-generate.toml
@@ -1,23 +1,8 @@
 [template]
 cargo_generate_version = ">=0.17.4"
 
-[placeholders.advanced]
-type = "bool"
-prompt = "Configure advanced template options?"
-default = false
-
-[conditional.'advanced'.placeholders.toolchain]
+[placeholders.toolchain]
 type = "string"
 prompt = "Rust toolchain (beware: nightly works only for riscv MCUs!)"
 choices = ["esp", "nightly"]
 default = "esp"
-
-[conditional.'advanced'.placeholders.hal]
-type = "bool"
-prompt = "Enable HAL support?"
-default = true
-
-[conditional.'advanced'.placeholders.std]
-type = "bool"
-prompt = "Enable STD support?"
-default = true

--- a/cmake/components/rust-{{project-name}}/CMakeLists.txt
+++ b/cmake/components/rust-{{project-name}}/CMakeLists.txt
@@ -34,13 +34,7 @@ else()
     set(CARGO_BUILD_ARG "--release")
 endif()
 
-{% if hal and std %}
 set(CARGO_BUILD_STD_ARG -Zbuild-std=std,panic_abort)
-{% elsif hal %}
-set(CARGO_BUILD_STD_ARG -Zbuild-std=core,alloc,panic_abort)
-{% else %}
-set(CARGO_BUILD_STD_ARG -Zbuild-std=core,panic_abort -Zbuild-std-features=panic_immediate_abort)
-{% endif %}
 
 if(IDF_VERSION_MAJOR GREATER "4")
 set(ESP_RUSTFLAGS "--cfg espidf_time64")

--- a/cmake/components/rust-{{project-name}}/Cargo.toml
+++ b/cmake/components/rust-{{project-name}}/Cargo.toml
@@ -23,7 +23,7 @@ experimental = ["esp-idf-svc/experimental"]
 
 [dependencies]
 log = "0.4"
-esp-idf-svc = { version = "0.49", default-features = false, features = ["std", "critical-section", "embassy-time-driver", "embassy-sync"] }
+esp-idf-svc = { version = "0.49", default-features = false, features = ["std", "native", "critical-section", "embassy-time-driver", "embassy-sync"] }
 
 [build-dependencies]
 embuild = "0.32.0"

--- a/cmake/components/rust-{{project-name}}/Cargo.toml
+++ b/cmake/components/rust-{{project-name}}/Cargo.toml
@@ -17,25 +17,13 @@ opt-level = "s"
 debug = true # Symbols are nice and they don't increase the size on Flash
 opt-level = "z"
 
-{%- if hal %}
 [features]
-{%- if std %}
-default = ["std", "embassy", "esp-idf-svc/native"]
-{%- else %}
-default = ["alloc", "embassy", "esp-idf-svc/native", "esp-idf-svc/panic_handler", "esp-idf-svc/alloc_handler"]
-{%- endif %}
-
-pio = ["esp-idf-svc/pio"]
-std = ["alloc", "esp-idf-svc/std"]
-alloc = ["esp-idf-svc/alloc"]
-nightly = ["esp-idf-svc/nightly"]
+default = []
 experimental = ["esp-idf-svc/experimental"]
-embassy = ["esp-idf-svc/embassy-sync", "esp-idf-svc/critical-section", "esp-idf-svc/embassy-time-driver"]
 
 [dependencies]
-log = { version = "0.4", default-features = false }
-esp-idf-svc = { version = "0.49", default-features = false }
+log = "0.4"
+esp-idf-svc = { version = "0.49", default-features = false, features = ["std", "critical-section", "embassy-time-driver", "embassy-sync"] }
 
 [build-dependencies]
 embuild = "0.32.0"
-{%- endif %}

--- a/cmake/components/rust-{{project-name}}/build.rs
+++ b/cmake/components/rust-{{project-name}}/build.rs
@@ -1,5 +1,3 @@
 fn main() {
-{%- if hal %}
     embuild::espidf::sysenv::output();
-{%- endif %}
 }


### PR DESCRIPTION
I think it is time to radically simplify the generated template and ask only what toolchain folks want to use:
* People routinely get confused with the `embassy` features -> make these mandatory in the generated `Cargo.toml`
* People are attempting to do `no_std` with `esp-idf-*` - which is pointless -> remove the `std` and `alloc` features from the generated `Cargo.toml`