### PR TITLE
Clarify comment about the required cc version

### DIFF
--- a/cargo/Cargo.toml
+++ b/cargo/Cargo.toml
@@ -28,4 +28,4 @@ esp-idf-svc = { version = "0.49", features = ["critical-section", "embassy-time-
 
 [build-dependencies]
 embuild = "0.32.0"
-cc = "=1.1.30" # Necessary until a new version of `esp-idf-sys` is released
+cc = "=1.1.30" # Version "1.1.30" necessary until a new version of `esp-idf-sys` is released


### PR DESCRIPTION
Hello there,

I spent a lot of time figuring out how to fix the following error:

```
error occurred: unknown target `riscv32imac_zicsr_zifencei-esp-espidf`
```

during `cargo build`.

Turns out the reason I had this error because I accidentally updated the cc version. I could not find any information online about the issue which lead to many hours spent trying to fix this. If the comment had the information that the cc version must be `1.1.30` I would have discovered the problem way sooner.

I suggest to include the required version number in the comment, what do you think?