### PR TITLE
Unify issue and PR templates with the other esp-idf- crates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: Bug report
 about: Create a report to help us improve
 title: ''
-labels: bug
+labels: ["bug", "status:needs-attention"]
 assignees: ''
 
 ---
@@ -27,30 +27,19 @@ matrix channel (https://matrix.to/#/#esp-rs:matrix.org) or open the issue-->
 
 ## To Reproduce
 
-Steps to reproduce the behavior:
-
+<!-- Steps to reproduce the behavior. -->
 1. ...
 2. ...
-3. ...
-4. ...
 
-<!-- Make sure you are able to reproduce the bug in the main branch, too. -->
+<!-- Please share the minimal repro of the issue where the bug can be reproduced. -->
 
 ## Expected behavior
 
-<!-- A clear and concise description of what you expected to happen. -->
-
-## Screenshots
-
-<!-- If applicable, add screenshots to help explain your problem. -->
+<!-- A clear and concise description of what you expected to happen. Attach screenshots if needed. -->
 
 ## Environment
 
-<!-- Please fill the following information. -->
-
+- ESP-IDF branch or tag: [e.g. release/v5.2, v5.2.1, etc.] <!-- if you use the cargo-based build, you have the ESP-IDF version inside the `.cargo/config.toml` file of your binary crate, variable `ESP_IDF_VERSION` in section [env] . -->
+- Target device (MCU): [e.g. esp32s3] <!-- if you use the cargo-based build, you have the MCU inside the `.cargo/config.toml` file of your binary crate, variable `MCU` in section [env] . -->
 - OS: [e.g. Ubuntu 20.04]
 - How did you install the environment: [e.g. espup 0.3.2]
-
-## Additional context
-
-<!-- Add any other context about the problem here. -->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,1 +1,5 @@
 blank_issues_enabled: true
+contact_links:
+  - name: Ask questions in Matrix channel
+    url: https://matrix.to/#/#esp-rs:matrix.org
+    about: Ask any questions directly in our Matrix channel.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,16 +2,14 @@
 name: Feature request
 about: Suggest an idea for this project
 title: ''
-labels: enhancement
+labels: ["enhancement", "status:needs-attention"]
 assignees: ''
 
 ---
 
 ## Motivations
 
-<!--
-If your feature request is related to a problem, please describe it.
--->
+<!-- If your feature request is related to a problem, please describe it. -->
 
 - Would you like to implement this feature? [y/n]
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,18 @@
+## Thank you for your contribution!
+
+We appreciate the time and effort you've put into this pull request.
+To help us review it efficiently, please ensure you've gone through the following checklist:
+
+### Submission Checklist 📝
+- [ ] I have updated existing examples or added new ones (if applicable).
+- [ ] I have used `cargo fmt` command to ensure that all changed code is formatted correctly.
+- [ ] I have used `cargo clippy` command to ensure that all changed code passes latest Clippy nightly lints.
+- [ ] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-idf-template/blob/main/esp-idf-template/CHANGELOG.md) in the **_proper_** section.
+
+### Pull Request Details 📖
+
+#### Description
+Please provide a clear and concise description of your changes, including the motivation behind these changes. The context is crucial for the reviewers.
+
+#### Testing
+Describe how you tested your changes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Deprecated
+
+### Breaking
+
+### Added
+
+### Fixed


### PR DESCRIPTION
Subject says it all. A few minor changes so that the PR and issue reporting templates look the same across the (not-yet-mono-repoed) `esp-idf-*` crates.