### PR TITLE
Fix Github CI for Risc-v targets

### DIFF
--- a/cargo/.github/workflows/rust_ci.yml
+++ b/cargo/.github/workflows/rust_ci.yml
@@ -35,7 +35,7 @@ jobs:
         uses: dtolnay/rust-toolchain@v1
         with:
           toolchain: nightly
-          components: rust-src
+          components: rust-src rustfmt clippy
       {%- else %}
         uses: esp-rs/xtensa-toolchain@v1.5
         with:
@@ -45,6 +45,10 @@ jobs:
       {%- endif %}
       - name: Enable caching
         uses: Swatinem/rust-cache@v2
+      {%- if arch == "riscv" %}
+      - name: Install ldproxy
+        run: cargo install ldproxy  
+      {%- endif %}
       - name: Run command
         {%- raw %}
         run: cargo ${{ matrix.action.command }} ${{ matrix.action.args }}


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo fmt` command to ensure that all changed code is formatted correctly.
- [x] I have used `cargo clippy` command to ensure that all changed code passes latest Clippy nightly lints.
- [ ] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-idf-template/blob/main/esp-idf-template/CHANGELOG.md) in the **_proper_** section.

### Pull Request Details 📖
The Github CI currently fails if the target is risc-v
See [here](https://github.com/kaaax0815/smart-hot-water-tank/actions/runs/12536986335/job/34960602507) and [here](https://github.com/kaaax0815/smart-hot-water-tank/actions/runs/12537065306/job/34960766443)

#### Description

- Add `rustfmt` and `clippy` to components for nightly toolchain
- Install ldproxy

#### Testing
In my own project https://github.com/kaaax0815/smart-hot-water-tank/commit/204e20b052220132416e99181ec923dd40da64f5