### PR TITLE
Update to the newly-released crates; use ESP IDF V5.3 (latest stable) and V5.2 (previous stable)

### DIFF
--- a/.github/workflows/ci_cargo.yml
+++ b/.github/workflows/ci_cargo.yml
@@ -28,8 +28,8 @@ jobs:
       matrix:
         target: ["esp32", "esp32c3", "esp32c2", "esp32c6", "esp32h2", "esp32s2", "esp32s3"]
         esp-idf:
-          - version: v5.3.2
-          - version: v5.2.2
+          - version: v5.3
+          - version: v5.2
           # - version: master
     steps:
       - name: Setup | Rust (RISC-V)

--- a/.github/workflows/ci_cargo.yml
+++ b/.github/workflows/ci_cargo.yml
@@ -28,8 +28,8 @@ jobs:
       matrix:
         target: ["esp32", "esp32c3", "esp32c2", "esp32c6", "esp32h2", "esp32s2", "esp32s3"]
         esp-idf:
-          - version: v5.2
-          - version: v5.1 # only for compairson why no_std build fails on v5.2
+          - version: v5.3.2
+          - version: v5.2.2
           # - version: master
     steps:
       - name: Setup | Rust (RISC-V)
@@ -69,17 +69,13 @@ jobs:
       - uses: actions/checkout@v4
         with:
           path: /home/runner/work/esp-idf-template/esp-idf-template/github-esp-idf-template
-      - name: Generate v5.2
-        if: matrix.esp-idf.version == 'v5.2' || matrix.esp-idf.version == 'v5.1'
+      - name: Generate
         run: cargo generate --path /home/runner/work/esp-idf-template/esp-idf-template/github-esp-idf-template cargo --name ${{ matrix.target }} --vcs none --silent -d mcu=${{ matrix.target }} -d advanced=true -d espidfver=${{ matrix.esp-idf.version }} -d devcontainer=false -d wokwi=false -d ci=false
       - name: Build | Fmt Check
-        if: matrix.esp-idf.version == 'v5.2' && matrix.target == 'esp32c3'
         run: cd ${{ matrix.target }}; cargo fmt -- --check
       - name: Build | Clippy
-        if: matrix.esp-idf.version == 'v5.2' || matrix.esp-idf.version == 'v5.1'
         run: cd ${{ matrix.target }}; cargo clippy --no-deps -- -Dwarnings
       - name: Build | Compile
-        if: matrix.esp-idf.version == 'v5.2' || matrix.esp-idf.version == 'v5.1'
         run: cd ${{ matrix.target }}; cargo build
   container-checks:
     name: "Container Check: ${{ matrix.target }}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Breaking
 
 ### Added
+- Update the template to the latest-released `esp-idf-svc`
+- Update the template to ESP-IDF V5.3 (latest stable)
 
 ### Fixed
 - Fixed the generated GH CI by making sure `ldproxy`, `cargo fmt`, `cargo clippy` and rust src for `-Zbuild-std` are operational with the nightly toolchain (#253)

--- a/README-cmake-details.md
+++ b/README-cmake-details.md
@@ -169,7 +169,7 @@ env:
   CARGO_TERM_COLOR: always
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   ESP_TARGET: esp32
-  ESP_IDF_VERSION: v5.1
+  ESP_IDF_VERSION: v5.3.2
 
 
 jobs:

--- a/README-cmake.md
+++ b/README-cmake.md
@@ -145,7 +145,7 @@ When using `idf.py` and CMake driven ESP-IDF projects, you need to [install the 
 Simple installation for Linux & MacOS:
 ```sh
 git clone https://github.com/espressif/esp-idf
-git -C esp-idf checkout release/v5.1
+git -C esp-idf checkout release/v5.3
 esp-idf/install.sh
 . esp-idf/export.sh
 ```
@@ -153,7 +153,7 @@ esp-idf/install.sh
 Simple installation for Windows:
 ```sh
 git clone https://github.com/espressif/esp-idf
-git -C esp-idf checkout release/v5.1
+git -C esp-idf checkout release/v5.3
 esp-idf\install
 esp-idf\export
 ```

--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ The command will display a few prompts:
 - `Which MCU to target?`: SoC model, e.g. `esp32`, `esp32s2`, `esp32c3` etc.
 - `Configure advanced template options?`: If `false`, skips the rest of the prompts and uses their default value. If `true`, you will be prompted with:
   - `ESP-IDF Version`: ESP-IDF branch/tag to use. Possible choices:
-    - [`v4.4`](https://github.com/espressif/esp-idf/releases/tag/v4.4.5): Stable
-    - [`v5.1`](https://github.com/espressif/esp-idf/releases/tag/v5.1): Stable
+    - [`v5.3`](https://github.com/espressif/esp-idf/releases/tag/v5.3.2): Stable
+    - [`v5.2`](https://github.com/espressif/esp-idf/releases/tag/v5.2.3): Stable
     - [`master`](https://github.com/espressif/esp-idf/tree/master): **Unstable**. Please do NOT choose the `master` ESP IDF version, unless you
       really have a very good reason to. Building against ESP IDF `master` is NOT officially supported, and can break any time.
    - `Configure project to support Wokwi simulation with Wokwi VS Code extension?`: Adds support for Wokwi simulation using [VS Code Wokwi extension](https://marketplace.visualstudio.com/items?itemName=wokwi.wokwi-vscode).

--- a/cargo/.cargo/config.toml
+++ b/cargo/.cargo/config.toml
@@ -19,5 +19,3 @@ ESP_IDF_VERSION = "v5.2.3"
 {% elsif espidfver == "master" %}
 ESP_IDF_VERSION = "master"
 {% endif %}
-# Workaround for https://github.com/esp-rs/esp-idf-template/issues/174 
-CRATE_CC_NO_DEFAULTS = "1"

--- a/cargo/.cargo/config.toml
+++ b/cargo/.cargo/config.toml
@@ -3,8 +3,8 @@ target = "{{ rust_target }}"
 
 [target.{{ rust_target }}]
 linker = "ldproxy"
-runner = "espflash flash --monitor" # Select this runner for espflash v3.x.x
-rustflags = [ "--cfg",  "espidf_time64"] # Extending time_t for ESP IDF 5: https://github.com/esp-rs/rust/issues/110
+runner = "espflash flash --monitor"
+rustflags = [ "--cfg",  "espidf_time64"]
 
 [unstable]
 build-std = ["std", "panic_abort"]
@@ -12,10 +12,10 @@ build-std = ["std", "panic_abort"]
 [env]
 MCU="{{ mcu }}"
 # Note: this variable is not used by the pio builder (`cargo build --features pio`)
-{%- if espidfver == "v5.1" %}
-ESP_IDF_VERSION = "v5.1.4"
+{%- if espidfver == "v5.3" %}
+ESP_IDF_VERSION = "v5.3.2"
 {% elsif espidfver == "v5.2" %}
-ESP_IDF_VERSION = "v5.2.2"
+ESP_IDF_VERSION = "v5.2.3"
 {% elsif espidfver == "master" %}
 ESP_IDF_VERSION = "master"
 {% endif %}

--- a/cargo/Cargo.toml
+++ b/cargo/Cargo.toml
@@ -24,8 +24,7 @@ experimental = ["esp-idf-svc/experimental"]
 
 [dependencies]
 log = "0.4"
-esp-idf-svc = { version = "0.49", features = ["critical-section", "embassy-time-driver", "embassy-sync"] }
+esp-idf-svc = { version = "0.50", features = ["critical-section", "embassy-time-driver", "embassy-sync"] }
 
 [build-dependencies]
-embuild = "0.32.0"
-cc = "=1.1.30" # Version "1.1.30" necessary until a new version of `esp-idf-sys` is released
+embuild = "0.33"

--- a/cargo/cargo-generate.toml
+++ b/cargo/cargo-generate.toml
@@ -19,8 +19,8 @@ default = false
 [conditional.'advanced'.placeholders.espidfver]
 type = "string"
 prompt = "ESP-IDF version (master = UNSTABLE)"
-choices = ["v5.1", "v5.2", "master"]
-default = "v5.2"
+choices = ["v5.3", "v5.2", "master"]
+default = "v5.3"
 
 [conditional.'advanced'.placeholders.devcontainer]
 type = "bool"

--- a/cmake/components/rust-{{project-name}}/Cargo.toml
+++ b/cmake/components/rust-{{project-name}}/Cargo.toml
@@ -23,7 +23,7 @@ experimental = ["esp-idf-svc/experimental"]
 
 [dependencies]
 log = "0.4"
-esp-idf-svc = { version = "0.49", default-features = false, features = ["std", "native", "critical-section", "embassy-time-driver", "embassy-sync"] }
+esp-idf-svc = { version = "0.50", default-features = false, features = ["std", "native", "critical-section", "embassy-time-driver", "embassy-sync"] }
 
 [build-dependencies]
-embuild = "0.32.0"
+embuild = "0.33"


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [v] I have updated existing examples or added new ones (if applicable).
- [v] I have used `cargo fmt` command to ensure that all changed code is formatted correctly.
- [v] I have used `cargo clippy` command to ensure that all changed code passes latest Clippy nightly lints.
- [v] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-idf-template/blob/main/esp-idf-template/CHANGELOG.md) in the **_proper_** section.

### Pull Request Details 📖

#### Description

As per the subject:
- `esp-idf-svc` (and `embuild`) updated to the just-released versions
- Since we finally can build ourselves against latest stable ESP-IDF, the template is changed to offer by default V5.3, and then V5.2 as a backup, and `master` for the brave ones, as usu.

#### Testing
The CI would test it all!