### PR TITLE
fix: prevent ci jobs from running twice on pull requests

### DIFF
--- a/cargo/.github/workflows/rust_ci.yml
+++ b/cargo/.github/workflows/rust_ci.yml
@@ -2,6 +2,8 @@ name: Continuous Integration
 
 on:
   push:
+    branches:
+      - main
     paths-ignore:
       - "**/README.md"
   pull_request:


### PR DESCRIPTION
### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo fmt` command to ensure that all changed code is formatted correctly.
- [x] I have used `cargo clippy` command to ensure that all changed code passes latest Clippy nightly lints.
- [ ] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-idf-template/blob/main/esp-idf-template/CHANGELOG.md) in the **_proper_** section.

### Pull Request Details 📖

#### Description
Fixes same problem as in upstream esp-generate: https://github.com/esp-rs/esp-generate/pull/140
> Currently CI jobs run both on pull_request and push, which causes them to run twice on each push to a PR. I restricted on.push.branches to main to prevent that.

Let me know if changelog entry is needed here.

#### Testing
Tested on private project using this template.