### PR TITLE
Specify ESP Toolchain Version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,3 +18,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fixed the generated GH CI by making sure `ldproxy`, `cargo fmt`, `cargo clippy` and rust src for `-Zbuild-std` are operational with the nightly toolchain (#253)
+- Update the README to specify 1.85.0 as the version to install with espup so core and std compile properly

--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ cargo install cargo-espflash # Optional
 ### Install Rust & Clang toolchains for Espressif SoCs (with `espup`)
 
 ```sh
-espup install
+espup install -v 1.85.0
 # Unix
 . $HOME/export-esp.sh
 ```


### PR DESCRIPTION
By default, espup installs Xtensa Rust 1.86.0.0 toolchain, which errors while building a project created with the template where rust fails to compile core without any direct indication of the root problem:

```
error: cannot find a built-in macro with name `contracts_ensures`
    --> /home/jwjbadger/.rustup/toolchains/esp/lib/rustlib/src/rust/library/core/src/macros/mod.rs:1789:5
     |
1789 | /     pub macro contracts_ensures($item:item) {
1790 | |         /* compiler built-in */
1791 | |     }
     | |_____^
```

I believe this is due to a version mismatch where rustc installs at version 1.85.0 causing it to fail to compile core, but I'm not entirely sure. Rolling back to 1.85.0 resolves the issue for now. I have updated the README to make note of this.

### Submission Checklist 📝
- [ x] I have updated existing examples or added new ones (if applicable).
- [ x] I have used `cargo fmt` command to ensure that all changed code is formatted correctly.
- [ x] I have used `cargo clippy` command to ensure that all changed code passes latest Clippy nightly lints.
- [x ] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-idf-template/blob/main/esp-idf-template/CHANGELOG.md) in the **_proper_** section.